### PR TITLE
Fix vertex shader code in EffectPass (EffectPassのvertexShaderコードの修正)

### DIFF
--- a/src/Graphics/EffectPass.cpp
+++ b/src/Graphics/EffectPass.cpp
@@ -38,6 +38,7 @@ out VertexData {
 
 void main()
 {
+	gl_Position = vec4(Position.xyz, 1.0);
 	Out.Position = vec4(Position.xyz, 1.0);
 	Out.TextureCoord = TextureCoord.xy;
 }


### PR DESCRIPTION
＞なぜか描画がうまくいかない件

使用されていたEffectPassのvertexShaderのコードで,
gl_Positionへの出力が抜けていました. ( GLSL 330 で SV_Position に相当する出力 )

この一行を追加すると, グラデーションされた fullscreen-quad が描画されることが確認できました.
