### PR TITLE
Add CMake build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,12 +30,7 @@
 /build.xcodefiles
 
 # CMake
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Makefile
-cmake_install.cmake
-install_manifest.txt
+/build.cmake
 
 # Visual Studio
 *.opendb

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ script:
   - xcodebuild -project examples/QuickStart/Builds/QuickStart.xcodeproj clean
   - xcodebuild -project examples/QuickStart/Builds/QuickStart.xcodeproj
   - build/build/Release/PomdogUnitTest
+  - mkdir build.cmake && cd build.cmake
+  - cmake -G Xcode ..
+  - cd ..
+  - xcodebuild -project build.cmake/Pomdog.xcodeproj
+  - build.cmake/build/PomdogTest/Debug/PomdogTest
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+project(Pomdog CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# add_subdirectory(build/pomdog)
+add_subdirectory(build/PomdogTest)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,22 +6,38 @@ configuration: Debug
 clone_depth: 15
 
 init:
-- git config --global core.autocrlf input
+  - git config --global core.autocrlf input
 
 install:
-- git submodule update --init --quiet
-- git clone -q --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
+  - git submodule update --init --quiet
+  - git clone -q --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
 
 before_build:
-- ps: >-
-    python tools/gyp/gyp_main.py test/FrameworkTest/unittest.gyp `
-        --depth=. -f msvs -G msvs_version=2017 `
-        --generator-output=build.msvs `
-        -D component=static_library
+  # for GYP
+  - ps: >-
+      python tools/gyp/gyp_main.py test/FrameworkTest/unittest.gyp `
+          --depth=. -f msvs -G msvs_version=2017 `
+          --generator-output=build.msvs `
+          -D component=static_library
+  # for CMake
+  - ps: mkdir build.cmake
+  - ps: cd build.cmake
+  - ps: cmake ../build/PomdogTest/
+  - ps: cd ..
 
+# for GYP
 build:
   project: build.msvs/test/FrameworkTest/unittest.sln
   verbosity: minimal
 
+# for CMake
+after_build:
+  - ps: cd build.cmake
+  - ps: cmake --build . --config Release
+  - ps: cd ..
+
 test_script:
-- ps: build.msvs/test/FrameworkTest/Debug/unittest
+  # for GYP
+  - ps: build.msvs/test/FrameworkTest/Debug/unittest
+  # for CMake
+  - ps: build.cmake/Release/PomdogTest

--- a/build/PomdogTest/CMakeLists.txt
+++ b/build/PomdogTest/CMakeLists.txt
@@ -1,0 +1,173 @@
+cmake_minimum_required(VERSION 3.10)
+project(PomdogTest CXX)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+set(PRODUCT_NAME PomdogTest)
+set(POMDOG_DIR "../..")
+set(POMDOG_TEST_DIR "${POMDOG_DIR}/test/FrameworkTest")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_EXTENSIONS off)
+set(CMAKE_CONFIGURATION_TYPES Debug Release)
+
+set(SOURCE_FILES
+  ${POMDOG_TEST_DIR}/main.cpp
+  ${POMDOG_TEST_DIR}/Application/GameClockTest.cpp
+  ${POMDOG_TEST_DIR}/Application/TimerTest.cpp
+  ${POMDOG_TEST_DIR}/Content/PathHelperTest.cpp
+  ${POMDOG_TEST_DIR}/Async/SchedulerTest.cpp
+  ${POMDOG_TEST_DIR}/Async/TaskTest.cpp
+
+  ${POMDOG_TEST_DIR}/Experimental/Gameplay/EntityIDTest.cpp
+  ${POMDOG_TEST_DIR}/Experimental/Gameplay/EntityTest.cpp
+  ${POMDOG_TEST_DIR}/Experimental/Gameplay/EntityManagerTest.cpp
+
+  ${POMDOG_TEST_DIR}/Graphics/InputLayoutHelperTest.cpp
+  ${POMDOG_TEST_DIR}/Input/KeyboardStateTest.cpp
+  ${POMDOG_TEST_DIR}/Input/KeysTest.cpp
+  ${POMDOG_TEST_DIR}/Input/MouseStateTest.cpp
+  ${POMDOG_TEST_DIR}/Logging/LogChannelTest.cpp
+  ${POMDOG_TEST_DIR}/Logging/LogTest.cpp
+  ${POMDOG_TEST_DIR}/Math/BoundingBoxTest.cpp
+  ${POMDOG_TEST_DIR}/Math/BoundingBox2DTest.cpp
+  ${POMDOG_TEST_DIR}/Math/BoundingCircleTest.cpp
+  ${POMDOG_TEST_DIR}/Math/BoundingFrustumTest.cpp
+  ${POMDOG_TEST_DIR}/Math/BoundingSphereTest.cpp
+  ${POMDOG_TEST_DIR}/Math/ColorTest.cpp
+  ${POMDOG_TEST_DIR}/Math/MathHelperTest.cpp
+  ${POMDOG_TEST_DIR}/Math/Matrix2x2Test.cpp
+  ${POMDOG_TEST_DIR}/Math/Matrix3x2Test.cpp
+  ${POMDOG_TEST_DIR}/Math/Matrix3x3Test.cpp
+  ${POMDOG_TEST_DIR}/Math/Matrix4x4Test.cpp
+  ${POMDOG_TEST_DIR}/Math/PlaneTest.cpp
+  ${POMDOG_TEST_DIR}/Math/Point2DTest.cpp
+  ${POMDOG_TEST_DIR}/Math/Point3DTest.cpp
+  ${POMDOG_TEST_DIR}/Math/QuaternionTest.cpp
+  ${POMDOG_TEST_DIR}/Math/RayTest.cpp
+  ${POMDOG_TEST_DIR}/Math/RectangleTest.cpp
+  ${POMDOG_TEST_DIR}/Math/Vector2Test.cpp
+  ${POMDOG_TEST_DIR}/Math/Vector3Test.cpp
+  ${POMDOG_TEST_DIR}/Math/Vector4Test.cpp
+  ${POMDOG_TEST_DIR}/Signals/ConnectionTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/ConnectionListTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/EventQueueTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/EventTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/HelpersTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/ScopedConnectionTest.cpp
+  ${POMDOG_TEST_DIR}/Signals/SignalTest.cpp
+  ${POMDOG_TEST_DIR}/Utility/AnyTest.cpp
+  ${POMDOG_TEST_DIR}/Utility/CRC32Test.cpp
+  ${POMDOG_TEST_DIR}/Utility/OptionalTest.cpp
+  ${POMDOG_TEST_DIR}/Utility/StringHelperTest.cpp
+)
+
+include_directories(
+  ${POMDOG_DIR}/include
+  ${POMDOG_DIR}/experimental
+  ${POMDOG_DIR}/dependencies/iutest/include
+)
+
+add_executable(${PRODUCT_NAME} ${SOURCE_FILES})
+
+target_compile_definitions(${PRODUCT_NAME} PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG;DEBUG=1>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+  IUTEST_CHECK_STRICT=0
+)
+
+if(APPLE)
+  # TODO: Replace with the following, CMake >= 3.12
+  # `target_link_options(${PRODUCT_NAME} PUBLIC "${LINK_FRAMEWORKS}")`
+  # https://cmake.org/cmake/help/git-stage/command/target_link_options.html
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Metal")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework AudioToolBox")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenAL")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Cocoa")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenGL")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework QuartzCore")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINK_FRAMEWORKS}")
+endif()
+
+if(WIN32)
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    /W4
+    /WX
+    "$<$<CONFIG:DEBUG>:/Od;/MTd>"
+    "$<$<CONFIG:RELEASE>:/O2;/Ob2;/MT>"
+  )
+
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+  )
+
+  # Replace with target_link_options() when upgrading CMake 3.12
+  target_link_libraries(${PRODUCT_NAME}
+    debug -INCREMENTAL
+    debug -DEBUG
+    optimized -INCREMENTAL:NO
+    optimized -OPT:REF
+  )
+endif()
+
+set_target_properties(
+  ${PRODUCT_NAME} PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_OTHER_CFLAGS[variant=Debug] "-g"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+
+  # Warnings (Clang)
+  XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_ENUM_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_INT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_UNREACHABLE_CODE "YES"
+
+  # Warnings (GCC and Clang)
+  XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_NEWLINE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_RETURN_TYPE "YES_ERROR"
+  XCODE_ATTRIBUTE_GCC_WARN_CHECK_SWITCH_STATEMENTS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_MISSING_PARENTHESES "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_NON_VIRTUAL_DESTRUCTOR "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SHADOW "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SIGN_COMPARE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_TYPECHECK_CALLS_TO_PRINTF "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNINITIALIZED_AUTOS "YES_AGGRESSIVE"
+  XCODE_ATTRIBUTE_GCC_WARN_UNKNOWN_PRAGMAS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_LABEL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VALUE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE "YES"
+
+  # Warnings - Objective-C
+  XCODE_ATTRIBUTE_CLANG_WARN_DIRECT_OBJC_ISA_USAGE "YES_ERROR"
+  XCODE_ATTRIBUTE_CLANG_WARN__DUPLICATE_METHOD_MATCH "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNDECLARED_SELECTOR "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_OBJC_ROOT_CLASS "YES_ERROR"
+
+  # Warning Policies
+  XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
+  XCODE_ATTRIBUTE_WARNING_CFLAGS "-Wall"
+
+  # Symbols
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
+  XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN "YES" # -fvisibility-inlines-hidden
+  XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES" # -fvisibility=hidden
+)
+
+add_subdirectory("${POMDOG_DIR}/build/pomdog_experimental" "${CMAKE_CURRENT_BINARY_DIR}/pomdog_experimental_build")
+target_link_libraries(${PRODUCT_NAME} pomdog_experimental)

--- a/build/dependencies/glew/CMakeLists.txt
+++ b/build/dependencies/glew/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.10)
+project(glew C)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+set(THIRDPARTY_DIR "../../../dependencies")
+
+add_library(glew_static STATIC
+  ${THIRDPARTY_DIR}/vendor/glew/include/GL/glew.h
+  ${THIRDPARTY_DIR}/vendor/glew/include/GL/glxew.h
+  ${THIRDPARTY_DIR}/vendor/glew/include/GL/wglew.h
+  ${THIRDPARTY_DIR}/vendor/glew/src/glew.c
+)
+
+target_include_directories(glew_static PRIVATE
+  ${THIRDPARTY_DIR}/vendor/glew/include
+)
+
+target_compile_definitions(glew_static PRIVATE GLEW_STATIC)
+
+target_compile_definitions(glew_static PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(glew_static PRIVATE
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(WIN32)
+  target_compile_options(glew_static PRIVATE
+    /nologo
+    /W3
+    /O2
+    /Ob1
+    /GF
+    /Gy
+    "$<$<CONFIG:DEBUG>:/MTd>"
+    "$<$<CONFIG:RELEASE>:/MT>"
+  )
+
+  target_compile_definitions(glew_static PRIVATE
+    WIN32
+    _LIB
+    WIN32_LEAN_AND_MEAN
+  )
+endif()

--- a/build/dependencies/libpng/CMakeLists.txt
+++ b/build/dependencies/libpng/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.10)
+project(libpng C)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+set(POMDOG_DIR "../../..")
+set(THIRDPARTY_DIR "../../../dependencies")
+
+add_library(
+  png STATIC
+  ${THIRDPARTY_DIR}/vendor/libpng/pnglibconf.h
+  ${THIRDPARTY_DIR}/libpng/png.c
+  ${THIRDPARTY_DIR}/libpng/png.h
+  ${THIRDPARTY_DIR}/libpng/pngconf.h
+  ${THIRDPARTY_DIR}/libpng/pngdebug.h
+  ${THIRDPARTY_DIR}/libpng/pngerror.c
+  ${THIRDPARTY_DIR}/libpng/pngget.c
+  ${THIRDPARTY_DIR}/libpng/pnginfo.h
+  ${THIRDPARTY_DIR}/libpng/pngmem.c
+  ${THIRDPARTY_DIR}/libpng/pngpread.c
+  ${THIRDPARTY_DIR}/libpng/pngpriv.h
+  ${THIRDPARTY_DIR}/libpng/pngread.c
+  ${THIRDPARTY_DIR}/libpng/pngrio.c
+  ${THIRDPARTY_DIR}/libpng/pngrtran.c
+  ${THIRDPARTY_DIR}/libpng/pngrutil.c
+  ${THIRDPARTY_DIR}/libpng/pngset.c
+  ${THIRDPARTY_DIR}/libpng/pngstruct.h
+  ${THIRDPARTY_DIR}/libpng/pngtrans.c
+  ${THIRDPARTY_DIR}/libpng/pngwio.c
+  ${THIRDPARTY_DIR}/libpng/pngwrite.c
+  ${THIRDPARTY_DIR}/libpng/pngwtran.c
+  ${THIRDPARTY_DIR}/libpng/pngwutil.c
+)
+
+target_include_directories(png PRIVATE
+  ${THIRDPARTY_DIR}/libpng
+  ${THIRDPARTY_DIR}/vendor/libpng
+  ${THIRDPARTY_DIR}/zlib
+)
+
+target_compile_definitions(png PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(png PRIVATE
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(WIN32)
+  target_compile_options(png PRIVATE
+    /nologo
+    /W4
+    /Ox
+    /Oi
+    /Gm-
+    /Gy
+    /fp:except-
+    /TC
+    /GF
+    /wd"4996"
+    /wd"4127"
+    /Zc:wchar_t-
+    "$<$<CONFIG:DEBUG>:/MTd>"
+    "$<$<CONFIG:RELEASE>:/MT>"
+  )
+
+  target_compile_definitions(png PRIVATE
+    WIN32
+    _WINDOWS
+  )
+endif()
+
+set_target_properties(png PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "YES"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+  XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+)
+
+add_subdirectory("${POMDOG_DIR}/build/dependencies/zlib" "${CMAKE_CURRENT_BINARY_DIR}/zlib_build")
+target_link_libraries(png INTERFACE z)

--- a/build/dependencies/zlib/CMakeLists.txt
+++ b/build/dependencies/zlib/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.10)
+project(zlib C)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+
+set(THIRDPARTY_DIR "../../../dependencies")
+
+add_library(z STATIC
+  ${THIRDPARTY_DIR}/zlib/adler32.c
+  ${THIRDPARTY_DIR}/zlib/compress.c
+  ${THIRDPARTY_DIR}/zlib/crc32.c
+  ${THIRDPARTY_DIR}/zlib/crc32.h
+  ${THIRDPARTY_DIR}/zlib/deflate.c
+  ${THIRDPARTY_DIR}/zlib/deflate.h
+  ${THIRDPARTY_DIR}/zlib/gzclose.c
+  ${THIRDPARTY_DIR}/zlib/gzguts.h
+  ${THIRDPARTY_DIR}/zlib/gzlib.c
+  ${THIRDPARTY_DIR}/zlib/gzread.c
+  ${THIRDPARTY_DIR}/zlib/gzwrite.c
+  ${THIRDPARTY_DIR}/zlib/infback.c
+  ${THIRDPARTY_DIR}/zlib/inffast.c
+  ${THIRDPARTY_DIR}/zlib/inffast.h
+  ${THIRDPARTY_DIR}/zlib/inffixed.h
+  ${THIRDPARTY_DIR}/zlib/inflate.c
+  ${THIRDPARTY_DIR}/zlib/inflate.h
+  ${THIRDPARTY_DIR}/zlib/inftrees.c
+  ${THIRDPARTY_DIR}/zlib/inftrees.h
+  ${THIRDPARTY_DIR}/zlib/trees.c
+  ${THIRDPARTY_DIR}/zlib/trees.h
+  ${THIRDPARTY_DIR}/zlib/uncompr.c
+  ${THIRDPARTY_DIR}/zlib/zconf.h
+  ${THIRDPARTY_DIR}/zlib/zlib.h
+  ${THIRDPARTY_DIR}/zlib/zutil.c
+  ${THIRDPARTY_DIR}/zlib/zutil.h
+)
+
+target_include_directories(z PRIVATE
+  ${THIRDPARTY_DIR}/zlib
+)
+
+target_compile_definitions(z PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(z PRIVATE
+    -Wno-implicit-function-declaration
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(WIN32)
+  target_compile_options(z PRIVATE
+    /nologo
+    /W3
+    /O2
+    /Ob1
+    /GF
+    /Gy
+    /GS-
+    "$<$<CONFIG:DEBUG>:/MTd>"
+    "$<$<CONFIG:RELEASE>:/MT>"
+  )
+
+  target_compile_definitions(z PRIVATE
+    WIN32
+    _WINDOWS
+    _CRT_NONSTDC_NO_DEPRECATE
+    _CRT_SECURE_NO_DEPRECATE
+    _CRT_NONSTDC_NO_WARNINGS
+    "$<$<CONFIG:RELEASE>:ASMV;ASMINF>"
+  )
+endif()
+
+set_target_properties(z PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "YES"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+  XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+)

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -1,0 +1,835 @@
+cmake_minimum_required(VERSION 3.10)
+project(Pomdog CXX)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+set(PRODUCT_NAME pomdog)
+set(POMDOG_DIR "../..")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_EXTENSIONS off)
+set(CMAKE_CONFIGURATION_TYPES Debug Release)
+
+source_group(Application              REGULAR_EXPRESSION "(include/Pomdog|src)/Application/*")
+source_group(Async                    REGULAR_EXPRESSION "(include/Pomdog|src)/Async/*")
+source_group(Audio                    REGULAR_EXPRESSION "(include/Pomdog|src)/Audio/*")
+source_group(Basic                    REGULAR_EXPRESSION "(include/Pomdog|src)/Basic/*")
+source_group(Content                  REGULAR_EXPRESSION "(include/Pomdog|src)/Content/*")
+source_group(Experimental             REGULAR_EXPRESSION "(include/Pomdog|src)/Experimental/*")
+source_group(Graphics                 REGULAR_EXPRESSION "(include/Pomdog|src)/Graphics/*")
+source_group(Input                    REGULAR_EXPRESSION "(include/Pomdog|src)/Input/*")
+source_group(Logging                  REGULAR_EXPRESSION "(include/Pomdog|src)/Logging/*")
+source_group(Math                     REGULAR_EXPRESSION "(include/Pomdog|src)/Math/*")
+source_group(Platform.Cocoa           REGULAR_EXPRESSION "(include/Pomdog/Platform/Cocoa|src/Platform.Cocoa)/*")
+source_group(Platform.Win32           REGULAR_EXPRESSION "(include/Pomdog/Platform/Win32|src/Platform.Win32)/*")
+source_group(Platform.X11             REGULAR_EXPRESSION "(include/Pomdog/Platform/X11|src/Platform.X11)/*")
+source_group(Reactive                 REGULAR_EXPRESSION "(include/Pomdog|src)/Reactive/*")
+source_group(Signals                  REGULAR_EXPRESSION "(include/Pomdog|src)/Signals/*")
+source_group(Utility                  REGULAR_EXPRESSION "(include/Pomdog|src)/Utility/*")
+source_group(Application              REGULAR_EXPRESSION "(include/Pomdog|src)/Application/*")
+source_group(InputSystem.DirectInput  REGULAR_EXPRESSION src/InputSystem.DirectInput/*)
+source_group(InputSystem              REGULAR_EXPRESSION src/InputSystem/*)
+source_group(Platform.Apple           REGULAR_EXPRESSION src/Platform.Apple/*)
+source_group(Platform.Linux           REGULAR_EXPRESSION src/Platform.Linux/*)
+source_group(RenderSystem             REGULAR_EXPRESSION src/RenderSystem/*)
+source_group(RenderSystem.DXGI        REGULAR_EXPRESSION src/RenderSystem.DXGI/*)
+source_group(RenderSystem.Direct3D    REGULAR_EXPRESSION src/RenderSystem.Direct3D/*)
+source_group(RenderSystem.Direct3D11  REGULAR_EXPRESSION src/RenderSystem.Direct3D11/*)
+source_group(RenderSystem.GL4         REGULAR_EXPRESSION src/RenderSystem.GL4/*)
+source_group(RenderSystem.Metal       REGULAR_EXPRESSION src/RenderSystem.Metal/*)
+source_group(RenderSystem.Vulkan      REGULAR_EXPRESSION src/RenderSystem.Vulkan/*)
+source_group(SoundSystem.OpenAL       REGULAR_EXPRESSION src/SoundSystem.OpenAL/*)
+source_group(SoundSystem.XAudio2      REGULAR_EXPRESSION src/SoundSystem.XAudio2/*)
+
+set(POMDOG_SOURCES_CORE
+  ${POMDOG_DIR}/include/Pomdog/Application/Duration.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/Game.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/GameClock.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/GameHost.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/GameWindow.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/MouseCursor.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/Timer.hpp
+  ${POMDOG_DIR}/include/Pomdog/Application/TimePoint.hpp
+  ${POMDOG_DIR}/include/Pomdog/Async/Helpers.hpp
+  ${POMDOG_DIR}/include/Pomdog/Async/ImmediateScheduler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Async/QueuedScheduler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Async/Scheduler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Async/Task.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/AudioClip.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/AudioChannels.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/AudioEmitter.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/AudioEngine.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/AudioListener.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/SoundEffect.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/SoundState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Audio/detail/ForwardDeclarations.hpp
+  ${POMDOG_DIR}/include/Pomdog/Basic/Export.hpp
+  ${POMDOG_DIR}/include/Pomdog/Basic/Platform.hpp
+  ${POMDOG_DIR}/include/Pomdog/Basic/Version.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/AssetManager.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/AssetBuilders/Builder.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/AssetBuilders/PipelineStateBuilder.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/AssetBuilders/ShaderBuilder.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/Utility/BinaryFileStream.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/Utility/BinaryReader.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/Utility/MakeFourCC.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/detail/AssetDictionary.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/detail/AssetLoaderContext.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/detail/AssetLoader.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/detail/AssetLoaders/AudioClipLoader.hpp
+  ${POMDOG_DIR}/include/Pomdog/Content/detail/AssetLoaders/Texture2DLoader.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/Blend.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/BlendDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/BlendOperation.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/BufferUsage.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ComparisonFunction.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ConstantBuffer.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/CullMode.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/DepthFormat.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/DepthStencilDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/DepthStencilOperation.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectAnnotation.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectConstantDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectReflection.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectVariableClass.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectVariableType.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/EffectVariable.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/FillMode.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/GraphicsCommandList.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/GraphicsCommandQueue.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/GraphicsDevice.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/IndexBuffer.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/IndexElementSize.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/InputClassification.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/InputElement.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/InputElementFormat.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/InputLayoutDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/InputLayoutHelper.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/PipelineState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/PipelineStateDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/PresentationParameters.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/PrimitiveTopology.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/RasterizerDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/RenderPass.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/RenderTarget2D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/RenderTargetBlendDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/SamplerDescription.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/SamplerState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/Shader.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ShaderLanguage.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ShaderPipelineStage.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/SurfaceFormat.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/StencilOperation.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/Texture.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/Texture2D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/TextureAddressMode.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/TextureFilter.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/VertexBuffer.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/VertexBufferBinding.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/Viewport.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/detail/ForwardDeclarations.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/detail/EffectBinaryParameter.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ShaderCompilers/GLSLCompiler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ShaderCompilers/HLSLCompiler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Graphics/ShaderCompilers/MetalCompiler.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/ButtonState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/Gamepad.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadButtons.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadCapabilities.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadDPad.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadThumbSticks.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/GamepadType.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/Keyboard.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/KeyboardState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/KeyState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/Keys.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/Mouse.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/MouseState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/PlayerIndex.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/TouchLocation.hpp
+  ${POMDOG_DIR}/include/Pomdog/Input/TouchLocationState.hpp
+  ${POMDOG_DIR}/include/Pomdog/Logging/Log.hpp
+  ${POMDOG_DIR}/include/Pomdog/Logging/LogChannel.hpp
+  ${POMDOG_DIR}/include/Pomdog/Logging/LogEntry.hpp
+  ${POMDOG_DIR}/include/Pomdog/Logging/LogLevel.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingBox.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingBox.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingBox2D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingCircle.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingFrustum.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/BoundingSphere.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Color.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/ContainmentType.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Degree.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/MathHelper.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Matrix2x2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Matrix3x2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Matrix3x3.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Matrix4x4.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Plane.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/PlaneIntersectionType.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Point2D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Point3D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Quaternion.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Radian.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Ray.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Rectangle.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Vector2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Vector3.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/Vector4.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/Coordinate2D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/Coordinate3D.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointMatrix3x2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointMatrix3x3.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointMatrix4x4.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointQuaternion.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointVector2.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointVector3.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/FloatingPointVector4.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/ForwardDeclarations.hpp
+  ${POMDOG_DIR}/include/Pomdog/Math/detail/TaggedArithmetic.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Observable.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/ObservableBase.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/ObservableBuilder.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Observer.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Subscriber.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/BufferOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/DebounceOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/DelayOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/DistinctOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/DoOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/FilterOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/FirstOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/LastOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/MapOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/MergeOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/ScanOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/SkipLastOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/SkipOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/TakeOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/TimeoutOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Operators/ZipOperator.hpp
+  ${POMDOG_DIR}/include/Pomdog/Reactive/Subjects/KeyDownSubject.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/Connection.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/ConnectionList.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/Event.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/EventQueue.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/Helpers.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/ScopedConnection.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/Signal.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/detail/EventBody.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/detail/ForwardDeclarations.hpp
+  ${POMDOG_DIR}/include/Pomdog/Signals/detail/SignalBody.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/Any.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/Assert.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/Exception.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/FileSystem.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/Optional.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/PathHelper.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/StringHelper.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/detail/CRC32.hpp
+  ${POMDOG_DIR}/include/Pomdog/Utility/detail/Tagged.hpp
+  ${POMDOG_DIR}/src/Application/GameClock.cpp
+  ${POMDOG_DIR}/src/Application/SubsystemScheduler.hpp
+  ${POMDOG_DIR}/src/Application/SystemEvents.hpp
+  ${POMDOG_DIR}/src/Application/Timer.cpp
+  ${POMDOG_DIR}/src/Application/TimeSource.hpp
+  ${POMDOG_DIR}/src/Async/ImmediateScheduler.cpp
+  ${POMDOG_DIR}/src/Async/QueuedScheduler.cpp
+  ${POMDOG_DIR}/src/Async/Task.cpp
+  ${POMDOG_DIR}/src/Audio/AudioClip.cpp
+  ${POMDOG_DIR}/src/Audio/AudioEngine.cpp
+  ${POMDOG_DIR}/src/Audio/SoundEffect.cpp
+  ${POMDOG_DIR}/src/Basic/ConditionalCompilation.hpp
+  ${POMDOG_DIR}/src/Content/AssetDictionary.cpp
+  ${POMDOG_DIR}/src/Content/AssetLoaderContext.cpp
+  ${POMDOG_DIR}/src/Content/AssetManager.cpp
+  ${POMDOG_DIR}/src/Content/AssetBuilders/PipelineStateBuilder.cpp
+  ${POMDOG_DIR}/src/Content/AssetBuilders/ShaderBuilder.cpp
+  ${POMDOG_DIR}/src/Content/AssetLoaders/AudioClipLoader.cpp
+  ${POMDOG_DIR}/src/Content/AssetLoaders/Texture2DLoader.cpp
+  ${POMDOG_DIR}/src/Content/Utility/DDSTextureReader.cpp
+  ${POMDOG_DIR}/src/Content/Utility/DDSTextureReader.hpp
+  ${POMDOG_DIR}/src/Content/Utility/MSWaveAudioLoader.cpp
+  ${POMDOG_DIR}/src/Content/Utility/MSWaveAudioLoader.hpp
+  ${POMDOG_DIR}/src/Content/Utility/PNGTextureReader.cpp
+  ${POMDOG_DIR}/src/Content/Utility/PNGTextureReader.hpp
+  ${POMDOG_DIR}/src/Graphics/ConstantBuffer.cpp
+  ${POMDOG_DIR}/src/Graphics/EffectBinaryParameter.cpp
+  ${POMDOG_DIR}/src/Graphics/EffectReflection.cpp
+  ${POMDOG_DIR}/src/Graphics/GraphicsCommandList.cpp
+  ${POMDOG_DIR}/src/Graphics/GraphicsCommandQueue.cpp
+  ${POMDOG_DIR}/src/Graphics/GraphicsDevice.cpp
+  ${POMDOG_DIR}/src/Graphics/IndexBuffer.cpp
+  ${POMDOG_DIR}/src/Graphics/InputLayoutHelper.cpp
+  ${POMDOG_DIR}/src/Graphics/PipelineState.cpp
+  ${POMDOG_DIR}/src/Graphics/RenderTarget2D.cpp
+  ${POMDOG_DIR}/src/Graphics/SamplerState.cpp
+  ${POMDOG_DIR}/src/Graphics/Texture2D.cpp
+  ${POMDOG_DIR}/src/Graphics/Viewport.cpp
+  ${POMDOG_DIR}/src/Graphics/VertexBuffer.cpp
+  ${POMDOG_DIR}/src/Graphics/ShaderCompilers/GLSLCompiler.cpp
+  ${POMDOG_DIR}/src/Graphics/ShaderCompilers/HLSLCompiler.cpp
+  ${POMDOG_DIR}/src/Graphics/ShaderCompilers/MetalCompiler.cpp
+  ${POMDOG_DIR}/src/Input/KeyboardState.cpp
+  ${POMDOG_DIR}/src/InputSystem/InputDeviceCreator.hpp
+  ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.cpp
+  ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.hpp
+  ${POMDOG_DIR}/src/Logging/Log.cpp
+  ${POMDOG_DIR}/src/Logging/LogChannel.cpp
+  ${POMDOG_DIR}/src/Math/BoundingBox.cpp
+  ${POMDOG_DIR}/src/Math/BoundingBox2D.cpp
+  ${POMDOG_DIR}/src/Math/BoundingCircle.cpp
+  ${POMDOG_DIR}/src/Math/BoundingFrustum.cpp
+  ${POMDOG_DIR}/src/Math/BoundingSphere.cpp
+  ${POMDOG_DIR}/src/Math/Color.cpp
+  ${POMDOG_DIR}/src/Math/MathHelper.cpp
+  ${POMDOG_DIR}/src/Math/Plane.cpp
+  ${POMDOG_DIR}/src/Math/Ray.cpp
+  ${POMDOG_DIR}/src/Math/Rectangle.cpp
+  ${POMDOG_DIR}/src/Math/detail/Coordinate2D.cpp
+  ${POMDOG_DIR}/src/Math/detail/Coordinate3D.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointMatrix2x2.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointMatrix3x2.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointMatrix3x3.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointMatrix4x4.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointQuaternion.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointVector2.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointVector3.cpp
+  ${POMDOG_DIR}/src/Math/detail/FloatingPointVector4.cpp
+  ${POMDOG_DIR}/src/RenderSystem/BufferBindMode.hpp
+  ${POMDOG_DIR}/src/RenderSystem/BufferHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem/BufferHelper.hpp
+  ${POMDOG_DIR}/src/RenderSystem/GraphicsCapabilities.hpp
+  ${POMDOG_DIR}/src/RenderSystem/GraphicsCommandListImmediate.cpp
+  ${POMDOG_DIR}/src/RenderSystem/GraphicsCommandListImmediate.hpp
+  ${POMDOG_DIR}/src/RenderSystem/GraphicsCommandQueueImmediate.cpp
+  ${POMDOG_DIR}/src/RenderSystem/GraphicsCommandQueueImmediate.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeBuffer.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeEffectReflection.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeGraphicsCommandList.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeGraphicsCommandQueue.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeGraphicsContext.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeGraphicsDevice.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativePipelineState.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeRenderTarget2D.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeSamplerState.hpp
+  ${POMDOG_DIR}/src/RenderSystem/NativeTexture2D.hpp
+  ${POMDOG_DIR}/src/RenderSystem/ShaderBytecode.hpp
+  ${POMDOG_DIR}/src/RenderSystem/ShaderCompileOptions.hpp
+  ${POMDOG_DIR}/src/RenderSystem/SurfaceFormatHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem/SurfaceFormatHelper.hpp
+  ${POMDOG_DIR}/src/RenderSystem/TextureHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem/TextureHelper.hpp
+  ${POMDOG_DIR}/src/Signals/Connection.cpp
+  ${POMDOG_DIR}/src/Signals/ConnectionList.cpp
+  ${POMDOG_DIR}/src/Signals/EventQueue.cpp
+  ${POMDOG_DIR}/src/Signals/ScopedConnection.cpp
+  ${POMDOG_DIR}/src/Utility/AlignedNew.hpp
+  ${POMDOG_DIR}/src/Utility/CRC32.cpp
+  ${POMDOG_DIR}/src/Utility/Noncopyable.hpp
+  ${POMDOG_DIR}/src/Utility/PathHelper.cpp
+  ${POMDOG_DIR}/src/Utility/ScopeGuard.hpp
+  ${POMDOG_DIR}/src/Utility/StringHelper.cpp
+)
+
+set(POMDOG_SOURCES_GL4
+  ${POMDOG_DIR}/src/RenderSystem.GL4/BlendStateGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/BlendStateGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/BufferGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/BufferGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/DepthStencilStateGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/DepthStencilStateGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/EffectReflectionGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/EffectReflectionGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/ErrorChecker.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/ErrorChecker.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/GraphicsContextGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/GraphicsContextGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/GraphicsDeviceGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/GraphicsDeviceGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/InputLayoutGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/InputLayoutGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/OpenGLContext.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/OpenGLPrerequisites.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/PipelineStateGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/PipelineStateGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/RasterizerStateGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/RasterizerStateGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/RenderTarget2DGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/RenderTarget2DGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/SamplerStateGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/SamplerStateGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/ShaderGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/ShaderGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/Texture2DGL4.cpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/Texture2DGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/TypesafeGL4.hpp
+  ${POMDOG_DIR}/src/RenderSystem.GL4/TypesafeHelperGL4.hpp
+)
+
+set(POMDOG_SOURCES_OPENAL
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/AudioClipAL.cpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/AudioClipAL.hpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/AudioEngineAL.cpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/AudioEngineAL.hpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/ContextOpenAL.cpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/ContextOpenAL.hpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/ErrorCheckerAL.cpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/ErrorCheckerAL.hpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/PrerequisitesOpenAL.hpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/SoundEffectAL.cpp
+  ${POMDOG_DIR}/src/SoundSystem.OpenAL/SoundEffectAL.hpp
+)
+
+set(POMDOG_SOURCES_APPLE
+  ${POMDOG_DIR}/src/Platform.Apple/FileSystemApple.mm
+  ${POMDOG_DIR}/src/Platform.Apple/TimeSourceApple.cpp
+  ${POMDOG_DIR}/src/Platform.Apple/TimeSourceApple.hpp
+)
+
+set(POMDOG_SOURCES_COCOA
+  ${POMDOG_DIR}/include/Pomdog/Platform/Cocoa/Bootstrap.hpp
+  ${POMDOG_DIR}/include/Pomdog/Platform/Cocoa/PomdogOpenGLView.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/Bootstrap.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/CocoaWindowDelegate.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/CocoaWindowDelegate.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameHostCocoa.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameHostCocoa.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameWindowCocoa.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameWindowCocoa.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/KeyboardCocoa.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/KeyboardCocoa.cpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/MouseCocoa.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/MouseCocoa.cpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/OpenGLContextCocoa.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/OpenGLContextCocoa.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/PomdogOpenGLView.mm
+)
+
+set(POMDOG_SOURCES_DIRECT3D
+  ${POMDOG_DIR}/src/RenderSystem.DXGI/DXGIFormatHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem.DXGI/DXGIFormatHelper.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D/HLSLCompiling.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D/HLSLCompiling.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D/HLSLReflectionHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D/HLSLReflectionHelper.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D/PrerequisitesDirect3D.hpp
+)
+
+set(POMDOG_SOURCES_DIRECT3D11
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/BufferDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/BufferDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/EffectReflectionDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/EffectReflectionDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/GraphicsContextDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/GraphicsContextDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/GraphicsDeviceDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/GraphicsDeviceDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/PipelineStateDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/PipelineStateDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/PrerequisitesDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/RenderTarget2DDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/RenderTarget2DDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/SamplerStateDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/SamplerStateDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/ShaderDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/ShaderDirect3D11.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/Texture2DDirect3D11.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Direct3D11/Texture2DDirect3D11.hpp
+)
+
+set(POMDOG_SOURCES_METAL
+  ${POMDOG_DIR}/src/RenderSystem.Metal/BufferMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/BufferMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/EffectReflectionMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/EffectReflectionMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/GraphicsContextMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/GraphicsContextMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/GraphicsDeviceMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/GraphicsDeviceMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/MetalFormatHelper.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/MetalFormatHelper.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/PipelineStateMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/PipelineStateMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/RenderTarget2DMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/RenderTarget2DMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/SamplerStateMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/SamplerStateMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/ShaderMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/ShaderMetal.mm
+  ${POMDOG_DIR}/src/RenderSystem.Metal/Texture2DMetal.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Metal/Texture2DMetal.mm
+  ${POMDOG_DIR}/include/Pomdog/Platform/Cocoa/PomdogMetalViewController.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameHostMetal.hpp
+  ${POMDOG_DIR}/src/Platform.Cocoa/GameHostMetal.mm
+  ${POMDOG_DIR}/src/Platform.Cocoa/PomdogMetalViewController.mm
+)
+
+set(POMDOG_SOURCES_VULKAN
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/BufferVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/BufferVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/EffectReflectionVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/EffectReflectionVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsCommandListVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsCommandListVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsCommandQueueVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsCommandQueueVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsDeviceVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/GraphicsDeviceVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/PipelineStateVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/PipelineStateVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/RenderTexture2DVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/RenderTexture2DVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/SamplerStateVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/SamplerStateVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/ShaderVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/ShaderVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/Texture2DVulkan.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/Texture2DVulkan.hpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/VulkanFormatHelper.cpp
+  ${POMDOG_DIR}/src/RenderSystem.Vulkan/VulkanFormatHelper.hpp
+)
+
+set(POMDOG_SOURCES_XAUDIO2
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/AudioClipXAudio2.cpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/AudioClipXAudio2.hpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/AudioEngineXAudio2.cpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/AudioEngineXAudio2.hpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/PrerequisitesXAudio2.hpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/SoundEffectXAudio2.cpp
+  ${POMDOG_DIR}/src/SoundSystem.XAudio2/SoundEffectXAudio2.hpp
+)
+
+set(POMDOG_SOURCES_DIRECTINPUT
+  ${POMDOG_DIR}/src/InputSystem.DirectInput/DeviceContextDirectInput.cpp
+  ${POMDOG_DIR}/src/InputSystem.DirectInput/DeviceContextDirectInput.hpp
+  ${POMDOG_DIR}/src/InputSystem.DirectInput/PrerequisitesDirectInput.hpp
+)
+
+set(POMDOG_SOURCES_WIN32
+  ${POMDOG_DIR}/include/Pomdog/Platform/Win32/Bootstrap.hpp
+  ${POMDOG_DIR}/include/Pomdog/Platform/Win32/BootstrapSettingsWin32.hpp
+  ${POMDOG_DIR}/include/Pomdog/Platform/Win32/PrerequisitesWin32.hpp
+  ${POMDOG_DIR}/src/Platform.Win32/Bootstrap.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/GameHostWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/GameHostWin32.hpp
+  ${POMDOG_DIR}/src/Platform.Win32/GameWindowWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/GameWindowWin32.hpp
+  ${POMDOG_DIR}/src/Platform.Win32/FileSystemWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/KeyboardWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/KeyboardWin32.hpp
+  ${POMDOG_DIR}/src/Platform.Win32/MouseWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/MouseWin32.hpp
+  ${POMDOG_DIR}/src/Platform.Win32/TimeSourceWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/TimeSourceWin32.hpp
+)
+
+set(POMDOG_SOURCES_WIN32_OPENGL
+  ${POMDOG_DIR}/src/Platform.Win32/OpenGLContextWin32.cpp
+  ${POMDOG_DIR}/src/Platform.Win32/OpenGLContextWin32.hpp
+)
+
+set(POMDOG_SOURCES_X11
+  ${POMDOG_DIR}/include/Pomdog/Platform/X11/Bootstrap.hpp
+  ${POMDOG_DIR}/src/Platform.X11/Bootstrap.cpp
+  ${POMDOG_DIR}/src/Platform.X11/GameHostX11.cpp
+  ${POMDOG_DIR}/src/Platform.X11/GameHostX11.hpp
+  ${POMDOG_DIR}/src/Platform.X11/GameWindowX11.cpp
+  ${POMDOG_DIR}/src/Platform.X11/GameWindowX11.hpp
+  ${POMDOG_DIR}/src/Platform.X11/KeyboardX11.cpp
+  ${POMDOG_DIR}/src/Platform.X11/KeyboardX11.hpp
+  ${POMDOG_DIR}/src/Platform.X11/MouseX11.cpp
+  ${POMDOG_DIR}/src/Platform.X11/MouseX11.hpp
+  ${POMDOG_DIR}/src/Platform.X11/OpenGLContextX11.cpp
+  ${POMDOG_DIR}/src/Platform.X11/OpenGLContextX11.hpp
+  ${POMDOG_DIR}/src/Platform.X11/X11AtomCache.hpp
+  ${POMDOG_DIR}/src/Platform.X11/X11Context.cpp
+  ${POMDOG_DIR}/src/Platform.X11/X11Context.hpp
+)
+
+set(POMDOG_SOURCES_LINUX
+  ${POMDOG_DIR}/src/Platform.Linux/FileSystemLinux.cpp
+  ${POMDOG_DIR}/src/Platform.Linux/TimeSourceLinux.cpp
+  ${POMDOG_DIR}/src/Platform.Linux/TimeSourceLinux.hpp
+)
+
+set(SOURCE_FILES ${POMDOG_SOURCES_CORE})
+
+if(APPLE)
+  set(POMDOG_TARGET_PLATFORM "Mac"   CACHE STRING "Choose platform")
+  set(POMDOG_USE_DIRECT3D11  false   CACHE BOOL   "Use Direct3D11")
+  set(POMDOG_USE_GL4         false   CACHE BOOL   "Use OpenGL4")
+  set(POMDOG_USE_METAL       true    CACHE BOOL   "Use Metal")
+  set(POMDOG_USE_VULKAN      false   CACHE BOOL   "Use Vulkan")
+  set(POMDOG_USE_OPENAL      true    CACHE BOOL   "Use OpenAL")
+  set(POMDOG_USE_XAUDIO2     false   CACHE BOOL   "Use XAudio2")
+  set(POMDOG_USE_DIRECTINPUT false   CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_X11         false   CACHE BOOL   "Use X11")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(POMDOG_TARGET_PLATFORM "Linux" CACHE STRING "Choose platform")
+  set(POMDOG_USE_DIRECT3D11  false   CACHE BOOL   "Use Direct3D11")
+  set(POMDOG_USE_GL4         true    CACHE BOOL   "Use OpenGL4")
+  set(POMDOG_USE_METAL       false   CACHE BOOL   "Use Metal")
+  set(POMDOG_USE_VULKAN      false   CACHE BOOL   "Use Vulkan")
+  set(POMDOG_USE_OPENAL      true    CACHE BOOL   "Use OpenAL")
+  set(POMDOG_USE_XAUDIO2     false   CACHE BOOL   "Use XAudio2")
+  set(POMDOG_USE_DIRECTINPUT false   CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_X11         true    CACHE BOOL   "Use X11")
+elseif(WIN32)
+  set(POMDOG_TARGET_PLATFORM "Win32" CACHE STRING "Choose platform")
+  set(POMDOG_USE_DIRECT3D11  true    CACHE BOOL   "Use Direct3D11")
+  set(POMDOG_USE_GL4         true    CACHE BOOL   "Use OpenGL4")
+  set(POMDOG_USE_METAL       false   CACHE BOOL   "Use Metal")
+  set(POMDOG_USE_VULKAN      false   CACHE BOOL   "Use Vulkan")
+  set(POMDOG_USE_OPENAL      false   CACHE BOOL   "Use OpenAL")
+  set(POMDOG_USE_XAUDIO2     true    CACHE BOOL   "Use XAudio2")
+  set(POMDOG_USE_DIRECTINPUT true    CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_X11         false   CACHE BOOL   "Use X11")
+endif()
+
+if(POMDOG_TARGET_PLATFORM MATCHES "Linux")
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_LINUX})
+elseif(POMDOG_TARGET_PLATFORM MATCHES "Mac")
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_APPLE})
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_COCOA})
+elseif(POMDOG_TARGET_PLATFORM MATCHES "Win32")
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_WIN32})
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_DIRECTINPUT})
+endif()
+
+if(POMDOG_USE_DIRECT3D11)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_DIRECT3D})
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_DIRECT3D11})
+endif()
+
+if(POMDOG_USE_GL4)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_GL4})
+endif()
+
+if(POMDOG_USE_GL4 AND (POMDOG_TARGET_PLATFORM MATCHES "Win32"))
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_WIN32_OPENGL})
+endif()
+
+if(POMDOG_USE_METAL)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_METAL})
+endif()
+
+if(POMDOG_USE_VULKAN)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_VULKAN})
+endif()
+
+if(POMDOG_USE_XAUDIO2)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_XAUDIO2})
+endif()
+
+if(POMDOG_USE_OPENAL)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_OPENAL})
+endif()
+
+if(POMDOG_USE_X11)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_X11})
+endif()
+
+# NOTE: Linking libraries for Mac and Xcode
+if(POMDOG_USE_METAL)
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/Metal.framework")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Metal")
+endif()
+
+if(POMDOG_USE_OPENAL AND (POMDOG_TARGET_PLATFORM MATCHES "Mac"))
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/AudioToolBox.framework")
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/OpenAL.framework")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework AudioToolBox")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenAL")
+endif()
+
+if(POMDOG_TARGET_PLATFORM MATCHES "Mac")
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/Cocoa.framework")
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/OpenGL.framework")
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/QuartzCore.framework")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Cocoa")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenGL")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework QuartzCore")
+endif()
+
+# NOTE: static library
+add_library(${PRODUCT_NAME} STATIC ${SOURCE_FILES})
+#install(TARGETS ${PRODUCT_NAME} DESTINATION lib)
+
+target_include_directories(${PRODUCT_NAME} PRIVATE
+  ${POMDOG_DIR}/include
+  ${POMDOG_DIR}/dependencies/libpng
+  ${POMDOG_DIR}/dependencies/vendor/libpng
+)
+
+add_subdirectory(${POMDOG_DIR}/build/dependencies/libpng "${CMAKE_CURRENT_BINARY_DIR}/libpng_build")
+target_link_libraries(${PRODUCT_NAME} INTERFACE png)
+
+if(POMDOG_USE_OPENAL AND (POMDOG_TARGET_PLATFORM MATCHES "Linux"))
+  target_link_libraries(${PRODUCT_NAME} INTERFACE openal)
+endif()
+
+if(POMDOG_USE_X11 AND (POMDOG_TARGET_PLATFORM MATCHES "Linux"))
+  target_include_directories(${PRODUCT_NAME} PRIVATE
+    /usr/X11R6/include
+    ${POMDOG_DIR}/dependencies/vendor/glew/include
+  )
+  link_directories(
+    /usr/X11R6/lib
+  )
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE GLEW_STATIC)
+
+  add_subdirectory(${POMDOG_DIR}/build/dependencies/glew "${CMAKE_CURRENT_BINARY_DIR}/glew_build")
+  target_link_libraries(${PRODUCT_NAME} INTERFACE X11 GL glew_static)
+endif()
+
+if(POMDOG_USE_GL4 AND (POMDOG_TARGET_PLATFORM MATCHES "Win32"))
+  target_include_directories(${PRODUCT_NAME} PRIVATE
+    ${POMDOG_DIR}/dependencies/vendor/glew/include
+  )
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE GLEW_STATIC)
+
+  add_subdirectory(${POMDOG_DIR}/build/dependencies/glew "${CMAKE_CURRENT_BINARY_DIR}/glew_build")
+  target_link_libraries(${PRODUCT_NAME} INTERFACE opengl32.lib glew_static)
+endif()
+
+if(POMDOG_USE_DIRECT3D11 AND (POMDOG_TARGET_PLATFORM MATCHES "Win32"))
+  target_link_libraries(${PRODUCT_NAME} INTERFACE
+    dxgi.lib
+    d3d11.lib
+    d3dcompiler.lib
+    dxguid.lib # for _IID_ID3D11ShaderReflection
+  )
+endif()
+
+if(POMDOG_USE_XAUDIO2 AND (POMDOG_TARGET_PLATFORM MATCHES "Win32"))
+  target_link_libraries(${PRODUCT_NAME} INTERFACE xaudio2.lib)
+endif()
+
+if(POMDOG_USE_DIRECTINPUT AND (POMDOG_TARGET_PLATFORM MATCHES "Win32"))
+  target_link_libraries(${PRODUCT_NAME} INTERFACE dinput8.lib dxguid.lib)
+endif()
+
+target_compile_definitions(${PRODUCT_NAME} PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG;DEBUG=1>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    -Wall
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(POMDOG_TARGET_PLATFORM MATCHES "Win32")
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    /W4
+    "$<$<CONFIG:DEBUG>:/Od;/MTd>"
+    "$<$<CONFIG:RELEASE>:/O2;/Ob2;/MT>"
+  )
+
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE
+    _WIN32_WINNT=0x0602 # Windows 8 or later
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+  )
+
+  target_link_libraries(${PRODUCT_NAME} INTERFACE
+    kernel32.lib
+    user32.lib
+    gdi32.lib
+    ole32.lib
+    winmm.lib
+    shell32.lib
+    # ws2_32.lib
+    # winspool.lib
+    # comdlg32.lib
+    # advapi32.lib
+    # oleaut32.lib
+    # uuid.lib
+    # odbc32.lib
+    # odbccp32.lib
+  )
+endif()
+
+if (POMDOG_TARGET_PLATFORM MATCHES "Mac")
+  # TODO: Replace with the following, CMake >= 3.12
+  # `target_link_options(${PRODUCT_NAME} PUBLIC "${LINK_FRAMEWORKS}")`
+  # https://cmake.org/cmake/help/git-stage/command/target_link_options.html
+  set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} ${LINK_FRAMEWORKS}")
+endif()
+
+# NOTE: For dynamic library
+# NOTE: see https://cmake.org/cmake/help/v3.9/prop_tgt/FRAMEWORK.html
+# set_target_properties(${PRODUCT_NAME} PROPERTIES
+#   XCODE_ATTRIBUTE_PRODUCT_NAME "Pomdog"
+#   XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "net.enginetrouble.pomdog"
+#   XCODE_ATTRIBUTE_INFOPLIST_FILE "src/Platform.Apple/Info.plist"
+#   XCODE_ATTRIBUTE_INSTALL_PATH "$(LOCAL_LIBRARY_DIR)/Frameworks"
+#   XCODE_ATTRIBUTE_DYLIB_INSTALL_NAME_BASE "@rpath"
+#   XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "$(inherited);@executable_path/../Frameworks;@loader_path/Frameworks"
+# )
+
+set_target_properties(${PRODUCT_NAME} PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "YES"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+
+  XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+
+  # Warnings (Clang)
+  XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_ENUM_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_INT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_UNREACHABLE_CODE "YES"
+
+  # Warnings (GCC and Clang)
+  XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_NEWLINE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_RETURN_TYPE "YES_ERROR"
+  XCODE_ATTRIBUTE_GCC_WARN_CHECK_SWITCH_STATEMENTS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_MISSING_PARENTHESES "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_NON_VIRTUAL_DESTRUCTOR "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SHADOW "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SIGN_COMPARE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_TYPECHECK_CALLS_TO_PRINTF "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNINITIALIZED_AUTOS "YES_AGGRESSIVE"
+  XCODE_ATTRIBUTE_GCC_WARN_UNKNOWN_PRAGMAS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_LABEL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VALUE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE "YES"
+
+  # Warnings - Objective-C
+  XCODE_ATTRIBUTE_CLANG_WARN_DIRECT_OBJC_ISA_USAGE "YES_ERROR"
+  XCODE_ATTRIBUTE_CLANG_WARN__DUPLICATE_METHOD_MATCH "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNDECLARED_SELECTOR "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_OBJC_ROOT_CLASS "YES_ERROR"
+
+  # Warning Policies
+  XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
+  XCODE_ATTRIBUTE_WARNING_CFLAGS "-Wall"
+
+  # Symbols
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
+  XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN "YES" # -fvisibility-inlines-hidden
+  XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES" # -fvisibility=hidden
+)

--- a/build/pomdog_experimental/CMakeLists.txt
+++ b/build/pomdog_experimental/CMakeLists.txt
@@ -1,0 +1,393 @@
+cmake_minimum_required(VERSION 3.10)
+project(Pomdog CXX)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+set(PRODUCT_NAME pomdog_experimental)
+set(POMDOG_DIR "../..")
+set(POMDOG_EXPERIMENTAL_DIR "../../experimental/Pomdog.Experimental")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_EXTENSIONS off)
+
+set(SOURCE_FILES
+  ${POMDOG_EXPERIMENTAL_DIR}/Experimental.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/Action.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/MoveToAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/RemoveActorAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/RotateToAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/ScaleToAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/SequenceAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/TintToAction.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Actions/detail/TemporalAction.hpp
+
+  # ${POMDOG_EXPERIMENTAL_DIR}/Compositing/RenderLayer.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Compositing/RenderLayer.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Compositing/RenderLayerCompositor.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Compositing/RenderLayerCompositor.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/Component.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/Entity.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/Entity.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/EntityContext.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/EntityContext.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/EntityID.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/EntityManager.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/EntityManager.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/Scene.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/Scene.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/detail/ComponentTypeIndex.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay/detail/ComponentTypeIndex.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/ActorComponent.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/ActorComponent.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Animator.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Animator.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/BeamRenderable.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/BeamRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/CameraComponent.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/CameraComponent.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Collider2D.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Collider2D.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/GameLevel.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/GraphicsComponent.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/GraphicsComponent.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/HierarchyNode.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/HierarchyNode.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/ParticleRenderable.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/ParticleRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/PrimitiveRenderable.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/PrimitiveRenderable.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/RectangleRenderable.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/RectangleRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Simple2DGameEngine.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Simple2DGameEngine.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/SkinnedMeshRenderable.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/SkinnedMeshRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/SpriteRenderable.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/SpriteRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/TextRenderable.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/TextRenderable.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Transform.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Gameplay2D/Transform.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/LineBatch.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/LineBatch.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/PolygonBatch.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/PolygonBatch.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/PolygonShapeBuilder.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/PolygonShapeBuilder.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/ScreenQuad.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/ScreenQuad.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SkinnedEffect.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SkinnedEffect.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteBatchRenderer.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteBatchRenderer.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteFont.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteFont.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteFontLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteFontLoader.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteLine.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteLine.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteSortMode.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteRenderer.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Graphics/SpriteRenderer.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/TrueTypeFont.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Graphics/TrueTypeFont.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/ChromaticAberration.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/ChromaticAberration.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/FishEyeEffect.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/FishEyeEffect.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/FXAA.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/FXAA.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/GrayscaleEffect.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/GrayscaleEffect.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/ImageEffectBase.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/PostProcessCompositor.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/PostProcessCompositor.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/RetroCrtEffect.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/RetroCrtEffect.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/SepiaToneEffect.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/SepiaToneEffect.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/VignetteEffect.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/ImageEffects/VignetteEffect.hpp
+
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/InGameEditor.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/InGameEditor.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/EditorBackground.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/EditorBackground.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/EditorColorScheme.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/PrimitiveAxes.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/PrimitiveAxes.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/PrimitiveGrid.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/InGameEditor/detail/PrimitiveGrid.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/VoxModel.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/VoxModelLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/VoxModelLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/VoxModelExporter.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/VoxModelExporter.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/MagicaVoxel/detail/VoxChunkHeader.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/Beam.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/BeamBranching.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/BeamEmitter.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/BeamSystem.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/BeamSystem.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/Particle.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleClip.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleClip.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleEmitter.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleSystem.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/ParticleSystem.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleCurveKey.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleCurveLerp.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleEmitterShape.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleEmitterShapeBox.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleEmitterShapeSector.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleParameter.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleParameterConstant.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleParameterCurve.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleParameterRandom.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Particle2D/detail/ParticleParameterRandomCurves.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationBlendInput.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationBlendInputType.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationClip.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationClip.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationGraph.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationNode.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationState.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationState.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationSystem.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationSystem.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationTimeInterval.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationTrack.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/AnimationTrack.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/CompressedFloat.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/Joint.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/JointIndex.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/JointPose.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/RigidSlot.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/RotationTrack.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/ScaleTrack.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/Skeleton.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/Skeleton.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkeletonHelper.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkeletonHelper.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkeletonPose.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkeletonPose.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkeletonTransform.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/Skin.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/Skin.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkinnedMesh.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkinnedMeshPart.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SkinnedVertex.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SpriteAnimationTrack.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/SpriteAnimationTrack.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/TranslationTrack.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationAdditiveNode.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationAdditiveNode.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationClipNode.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationClipNode.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationGraphWeight.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationGraphWeight.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationGraphWeightCollection.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationGraphWeightCollection.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationKeyHelper.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationLerpNode.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationLerpNode.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationTimer.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/AnimationTimer.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/WeightBlendingHelper.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Skeletal2D/detail/WeightBlendingHelper.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/AnimationGraphBuilder.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/AnimationGraphBuilder.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/AnimationLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/AnimationLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkeletonDesc.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkeletonDescLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkeletonDescLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkeletonLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkeletonLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkinLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkinLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkinnedMeshLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SkinnedMeshLoader.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SpriteAnimationLoader.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Spine/SpriteAnimationLoader.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Tween/EasingHelper.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Tween/EasingHelper.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/RenderCommand.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/RenderCommandProcessor.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Renderer.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Renderer.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/ParticleBatchCommand.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/ParticleBatchCommand.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/PrimitiveCommand.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/PrimitiveCommand.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/PrimitivePolygonCommand.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/PrimitivePolygonCommand.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/SkinnedMeshCommand.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/SkinnedMeshCommand.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/SpriteBatchCommand.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Commands/SpriteBatchCommand.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/ParticleBatchCommandProcessor.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/ParticleBatchCommandProcessor.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/PrimitiveCommandProcessor.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/PrimitiveCommandProcessor.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/PrimitivePolygonCommandProcessor.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/PrimitivePolygonCommandProcessor.hpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/SkinnedMeshCommandProcessor.cpp
+  # ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/SkinnedMeshCommandProcessor.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/SpriteBatchCommandProcessor.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Rendering/Processors/SpriteBatchCommandProcessor.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DebugNavigator.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DebugNavigator.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DisclosureTriangleButton.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DisclosureTriangleButton.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DrawingContext.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/DrawingContext.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/FontSize.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/FontWeight.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/HorizontalAlignment.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/HorizontalLayout.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/HorizontalLayout.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/HorizontalLine.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/HorizontalLine.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/PointerEventType.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/PointerPoint.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/ScenePanel.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/ScenePanel.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/Slider.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/Slider.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/StackPanel.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/StackPanel.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/TextBlock.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/TextBlock.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/Thickness.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/ToggleSwitch.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/ToggleSwitch.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/TreeView.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/TreeView.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIElement.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIElement.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIElementHierarchy.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIElementHierarchy.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIEventDispatcher.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIEventDispatcher.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/UIHelper.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/VerticalAlignment.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/VerticalLayout.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/VerticalLayout.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/detail/SubscribeRequestDispatcher.hpp
+  ${POMDOG_EXPERIMENTAL_DIR}/UI/detail/UIEventConnection.hpp
+
+  ${POMDOG_EXPERIMENTAL_DIR}/Utility/UserPreferences.cpp
+  ${POMDOG_EXPERIMENTAL_DIR}/Utility/UserPreferences.hpp
+)
+
+include_directories(
+  ${POMDOG_DIR}/experimental
+  ${POMDOG_DIR}/include
+  ${POMDOG_DIR}/dependencies/rapidjson/include
+  ${POMDOG_DIR}/dependencies/stb
+  ${POMDOG_DIR}/dependencies
+)
+
+add_library(${PRODUCT_NAME} STATIC ${SOURCE_FILES})
+
+target_compile_definitions(${PRODUCT_NAME} PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG;DEBUG=1>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(WIN32)
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    /W4
+    # /WX
+    "$<$<CONFIG:DEBUG>:/Od;/MTd>"
+    "$<$<CONFIG:RELEASE>:/O2;/Ob2;/MT>"
+  )
+
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE
+    _WIN32_WINNT=0x0602 # Windows 8 or later
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+  )
+endif()
+
+set_target_properties(
+  ${PRODUCT_NAME} PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "YES"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+
+  # Warnings (Clang)
+  XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_ENUM_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_INT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_UNREACHABLE_CODE "YES"
+
+  # Warnings (GCC and Clang)
+  XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_NEWLINE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_RETURN_TYPE "YES_ERROR"
+  XCODE_ATTRIBUTE_GCC_WARN_CHECK_SWITCH_STATEMENTS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_MISSING_PARENTHESES "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_NON_VIRTUAL_DESTRUCTOR "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SHADOW "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SIGN_COMPARE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_TYPECHECK_CALLS_TO_PRINTF "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNINITIALIZED_AUTOS "YES_AGGRESSIVE"
+  XCODE_ATTRIBUTE_GCC_WARN_UNKNOWN_PRAGMAS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_LABEL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VALUE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE "YES"
+
+  # Warnings - Objective-C
+  XCODE_ATTRIBUTE_CLANG_WARN_DIRECT_OBJC_ISA_USAGE "YES_ERROR"
+  XCODE_ATTRIBUTE_CLANG_WARN__DUPLICATE_METHOD_MATCH "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNDECLARED_SELECTOR "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_OBJC_ROOT_CLASS "YES_ERROR"
+
+  # Warning Policies
+  # XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
+
+  # Symbols
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
+  XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN "YES" # -fvisibility-inlines-hidden
+  XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES" # -fvisibility=hidden
+)
+
+add_subdirectory(${POMDOG_DIR}/build/pomdog ${CMAKE_CURRENT_BINARY_DIR}/pomdog_build)
+target_link_libraries(${PRODUCT_NAME} INTERFACE pomdog)

--- a/docs/Running-the-Tests.md
+++ b/docs/Running-the-Tests.md
@@ -1,0 +1,61 @@
+# Running the Tests
+
+## Build and run the unit tests on Linux
+
+```sh
+# Creating a build directory
+mkdir -p build.cmake && cd build.cmake
+
+# Generate Makefile
+cmake -G Xcode ../build/PomdogTest/
+
+# Compiling source code
+export CC=clang
+export CXX=clang++
+export LINK=clang++
+export CXXFLAGS="-std=c++17 -stdlib=libc++"
+export LDFLAGS="-stdlib=libc++"
+make
+
+# Run the unit tests
+./build/PomdogTest/PomdogTest        
+```
+
+## Build and run the unit tests on Mac OS X
+
+To run all unit tests, use:
+
+```sh
+cd path/to/pomdog
+
+# Creating a build directory
+mkdir -p build.cmake && cd build.cmake
+
+# Generating Xcode project files
+cmake -G Xcode ../build/PomdogTest/
+
+# Compiling source code
+xcodebuild -project PomdogTest.xcodeproj -configuration Release
+
+# Run the unit tests
+./Release/PomdogTest
+```
+
+## Build and run the unit tests on Windows
+
+```sh
+cd path/to/pomdog
+
+# Creating a build directory
+mkdir build.cmake
+cd build.cmake
+
+# Generating projects for Visual Studio 2017
+cmake -G "Visual Studio 15" ../build/PomdogTest/
+
+# Building projects using CMake and MSBuild
+cmake --build . --config Release
+
+# To run all unit tests, use the following:
+./Release/PomdogTest
+```

--- a/examples/QuickStart/CMakeLists.txt
+++ b/examples/QuickStart/CMakeLists.txt
@@ -1,0 +1,173 @@
+cmake_minimum_required(VERSION 3.10)
+project(QuickStart CXX)
+
+# NOTE: Remove /RTC1 option from default compiler options for Visual Studio
+STRING(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+set(PRODUCT_NAME QuickStart)
+set(POMDOG_DIR "../..")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_EXTENSIONS off)
+set(CMAKE_CONFIGURATION_TYPES Debug Release)
+
+set(SOURCE_FILES
+  Source/QuickStartGame.cpp
+  Source/QuickStartGame.hpp
+)
+
+set(RESOURCE_FILES Content)
+
+include_directories(
+  ${POMDOG_DIR}/include
+  ${POMDOG_DIR}/experimental
+  ${POMDOG_DIR}/dependencies/iutest/include
+)
+
+if(APPLE)
+  list(APPEND SOURCE_FILES
+    Platform.Cocoa/main.mm
+    Platform.Cocoa/AppDelegate.h
+    Platform.Cocoa/AppDelegate.mm
+    Platform.Cocoa/GameViewController.h
+    Platform.Cocoa/GameViewController.mm
+  )
+  list(APPEND RESOURCE_FILES
+    Platform.Cocoa/Assets.xcassets
+    Platform.Cocoa/Base.lproj/MainMenu.xib
+  )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  list(APPEND SOURCE_FILES
+    Platform.X11/main.cpp
+  )
+elseif(WIN32)
+  list(APPEND SOURCE_FILES
+    Platform.Win32/main.cpp
+    Platform.Win32/Resource.hpp
+    Platform.Win32/game.rc
+  )
+endif()
+
+add_executable(${PRODUCT_NAME} WIN32 ${SOURCE_FILES} ${RESOURCE_FILES})
+
+target_compile_definitions(${PRODUCT_NAME} PRIVATE
+  "$<$<CONFIG:DEBUG>:_DEBUG>"
+  "$<$<CONFIG:RELEASE>:NDEBUG>"
+)
+
+if ((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    -pedantic
+    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:RELEASE>:-O3>"
+  )
+endif()
+
+if(WIN32)
+  target_compile_options(${PRODUCT_NAME} PRIVATE
+    /W4
+    "$<$<CONFIG:DEBUG>:/Od;/MTd>"
+    "$<$<CONFIG:RELEASE>:/O2;/Ob2;/MT>"
+  )
+
+  target_compile_definitions(${PRODUCT_NAME} PRIVATE
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+  )
+
+  # Replace with target_link_options() when upgrading CMake 3.12
+  target_link_libraries(${PRODUCT_NAME}
+    debug -INCREMENTAL
+    debug -DEBUG
+    optimized -INCREMENTAL:NO
+    optimized -OPT:REF
+  )
+
+  set_target_properties(${PRODUCT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+endif()
+
+if(APPLE)
+  set_source_files_properties(
+    ${RESOURCE_FILES}
+    PROPERTIES
+    MACOSX_PACKAGE_LOCATION
+    Resources
+  )
+
+  set_target_properties(
+    ${PRODUCT_NAME} PROPERTIES
+    MACOSX_BUNDLE TRUE
+    RESOURCE "${RESOURCE_FILES}"
+  )
+
+  # TODO: Replace with the following, CMake >= 3.12
+  # `target_link_options(${PRODUCT_NAME} PUBLIC "${LINK_FRAMEWORKS}")`
+  # https://cmake.org/cmake/help/git-stage/command/target_link_options.html
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Metal")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework AudioToolBox")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenAL")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Cocoa")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework QuartzCore")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINK_FRAMEWORKS}")
+endif()
+
+set_target_properties(${PRODUCT_NAME} PROPERTIES
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Debug] "0" # -O0
+  XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL[variant=Release] "3" # -O3
+  XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH[variant=Debug] "YES"
+  XCODE_ATTRIBUTE_COMBINE_HIDPI_IMAGES "YES"
+
+  XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0"
+  XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++17"
+  XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++"
+  XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "10.11"
+
+  MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_LIST_DIR}/Platform.Cocoa/Info.plist
+  XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "$(inherited) @loader_path @executable_path/../Frameworks"
+
+  # Warnings (Clang)
+  XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_ENUM_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_INT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_UNREACHABLE_CODE "YES"
+
+  # Warnings (GCC and Clang)
+  XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_MISSING_NEWLINE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ABOUT_RETURN_TYPE "YES_ERROR"
+  XCODE_ATTRIBUTE_GCC_WARN_CHECK_SWITCH_STATEMENTS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_MISSING_PARENTHESES "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_NON_VIRTUAL_DESTRUCTOR "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SHADOW "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_SIGN_COMPARE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_TYPECHECK_CALLS_TO_PRINTF "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNINITIALIZED_AUTOS "YES_AGGRESSIVE"
+  XCODE_ATTRIBUTE_GCC_WARN_UNKNOWN_PRAGMAS "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_FUNCTION "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_LABEL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VALUE "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNUSED_VARIABLE "YES"
+
+  # Warnings - Objective-C
+  XCODE_ATTRIBUTE_CLANG_WARN_DIRECT_OBJC_ISA_USAGE "YES_ERROR"
+  XCODE_ATTRIBUTE_CLANG_WARN__DUPLICATE_METHOD_MATCH "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL "YES"
+  XCODE_ATTRIBUTE_GCC_WARN_UNDECLARED_SELECTOR "YES"
+  XCODE_ATTRIBUTE_CLANG_WARN_OBJC_ROOT_CLASS "YES_ERROR"
+
+  # Warning Policies
+  XCODE_ATTRIBUTE_GCC_TREAT_WARNINGS_AS_ERRORS "YES"
+
+  # Symbols
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
+  XCODE_ATTRIBUTE_GCC_INLINES_ARE_PRIVATE_EXTERN "YES" # -fvisibility-inlines-hidden
+  XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN "YES" # -fvisibility=hidden
+)
+
+add_subdirectory(${POMDOG_DIR}/build/pomdog ${CMAKE_CURRENT_BINARY_DIR}/pomdog_build)
+target_link_libraries(${PRODUCT_NAME} pomdog)

--- a/wercker.yml
+++ b/wercker.yml
@@ -9,7 +9,7 @@ build:
         git clone --depth=1 https://chromium.googlesource.com/external/gyp.git tools/gyp
 
     - script:
-      name: unittest
+      name: unittest-gyp
       code: |
         python tools/gyp.py test/FrameworkTest/unittest.gyp -f make
         export CC=clang
@@ -19,3 +19,18 @@ build:
         export LDFLAGS="-stdlib=libc++"
         make -C build.makefiles
         ./build.makefiles/out/Release/unittest
+
+    - script:
+      name: unittest-cmake
+      code: |
+        export CC=clang
+        export CXX=clang++
+        export LINK=clang++
+        export CXXFLAGS="-std=c++17 -stdlib=libc++"
+        export LDFLAGS="-stdlib=libc++"
+        mkdir build.cmake
+        cd build.cmake
+        cmake ..
+        make
+        cd ..
+        ./build.cmake/build/PomdogTest/PomdogTest


### PR DESCRIPTION
Hi there,

I (and we) would like to migrate from [GYP (Generate Your Projects)](https://gyp.gsrc.io/) to CMake build as a default Linux build system, for the following reasons:
- GYP requires Python 2.x, and it does not support Python 3, at the moment
- Chromium team uses [GN (Generate Ninja)](https://chromium.googlesource.com/chromium/src/+/master/tools/gn/docs/faq.md) instead of GYP
- CMake is pretty widely used in C++ projects (such as LLVM Clang)
- JetBrains CLion supports only CMake-based projects

Also I'm a CMake newbie :disappointed_relieved: , so could someone kindly help me review this pull request?
