### PR TITLE
Replace std::array<> with arrays in matrices

### DIFF
--- a/experimental/Pomdog.Experimental/Skeletal2D/detail/AnimationAdditiveNode.cpp
+++ b/experimental/Pomdog.Experimental/Skeletal2D/detail/AnimationAdditiveNode.cpp
@@ -7,6 +7,7 @@
 #include "Pomdog/Utility/Assert.hpp"
 #include "Pomdog/Math/Vector2.hpp"
 #include "Pomdog/Math/MathHelper.hpp"
+#include <algorithm>
 
 namespace Pomdog {
 namespace Detail {

--- a/include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp
+++ b/include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-#include <array>
 
 namespace Pomdog {
 namespace Detail {
@@ -18,7 +17,7 @@ public:
     static_assert(std::is_floating_point<T>::value, "T is floating point.");
     typedef T value_type;
 
-    std::array<std::array<T, 2>, 2> m;
+    T m[2][2];
 
 private:
     static constexpr std::size_t RowSize = 2;

--- a/include/Pomdog/Math/detail/FloatingPointMatrix3x2.hpp
+++ b/include/Pomdog/Math/detail/FloatingPointMatrix3x2.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-#include <array>
 
 namespace Pomdog {
 namespace Detail {
@@ -18,7 +17,7 @@ public:
     static_assert(std::is_floating_point<T>::value, "T is floating point.");
     typedef T value_type;
 
-    std::array<std::array<T, 2>, 3> m;
+    T m[3][2];
 
 private:
     static constexpr std::size_t RowSize = 3;

--- a/include/Pomdog/Math/detail/FloatingPointMatrix3x3.hpp
+++ b/include/Pomdog/Math/detail/FloatingPointMatrix3x3.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-#include <array>
 
 namespace Pomdog {
 namespace Detail {
@@ -18,7 +17,7 @@ public:
     static_assert(std::is_floating_point<T>::value, "T is floating point.");
     typedef T value_type;
 
-    std::array<std::array<T, 3>, 3> m;
+    T m[3][3];
 
 private:
     static constexpr std::size_t RowSize = 3;

--- a/include/Pomdog/Math/detail/FloatingPointMatrix4x4.hpp
+++ b/include/Pomdog/Math/detail/FloatingPointMatrix4x4.hpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-#include <array>
 
 namespace Pomdog {
 namespace Detail {
@@ -18,13 +17,7 @@ public:
     static_assert(std::is_floating_point<T>::value, "T is floating point.");
     typedef T value_type;
 
-    //union {
-    //    std::array<std::array<T, 4>, 4> m;
-    //#if defined __i386__ || defined __x86_64__
-    //    std::array<__m128, 4>
-    //#endif
-    //};
-    std::array<std::array<T, 4>, 4> m;
+    T m[4][4];
 
 private:
     static constexpr std::size_t RowSize = 4;

--- a/src/Math/detail/FloatingPointMatrix2x2.cpp
+++ b/src/Math/detail/FloatingPointMatrix2x2.cpp
@@ -191,14 +191,14 @@ template <typename T>
 const T* FloatingPointMatrix2x2<T>::Data() const noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>
 T* FloatingPointMatrix2x2<T>::Data() noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>

--- a/src/Math/detail/FloatingPointMatrix3x2.cpp
+++ b/src/Math/detail/FloatingPointMatrix3x2.cpp
@@ -381,14 +381,14 @@ template <typename T>
 const T* FloatingPointMatrix3x2<T>::Data() const noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>
 T* FloatingPointMatrix3x2<T>::Data() noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>

--- a/src/Math/detail/FloatingPointMatrix3x3.cpp
+++ b/src/Math/detail/FloatingPointMatrix3x3.cpp
@@ -626,14 +626,14 @@ template <typename T>
 const T* FloatingPointMatrix3x3<T>::Data() const noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>
 T* FloatingPointMatrix3x3<T>::Data() noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>

--- a/src/Math/detail/FloatingPointMatrix4x4.cpp
+++ b/src/Math/detail/FloatingPointMatrix4x4.cpp
@@ -1231,14 +1231,14 @@ template <typename T>
 const T* FloatingPointMatrix4x4<T>::Data() const noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>
 T* FloatingPointMatrix4x4<T>::Data() noexcept
 {
     static_assert(std::is_floating_point<T>::value, "T is floating point number");
-    return m[0].data();
+    return m[0];
 }
 
 template <typename T>

--- a/test/FrameworkTest/Math/Matrix2x2Test.cpp
+++ b/test/FrameworkTest/Math/Matrix2x2Test.cpp
@@ -73,3 +73,12 @@ TEST(Matrix2x2, Multiply_Matrix)
             Matrix2x2(3.0f, 4.0f, 8.0f, 9.0f),
             Matrix2x2(2.0f, 7.0f, 10.0f, 5.0f)));
 }
+
+TEST(Matrix2x2, Data)
+{
+    Matrix2x2 matrix{0.0f, 1.0f, 2.0f, 3.0f};
+    EXPECT_EQ(0.0f, *(matrix.Data() + 0));
+    EXPECT_EQ(1.0f, *(matrix.Data() + 1));
+    EXPECT_EQ(2.0f, *(matrix.Data() + 2));
+    EXPECT_EQ(3.0f, *(matrix.Data() + 3));
+}

--- a/test/FrameworkTest/Math/Matrix3x2Test.cpp
+++ b/test/FrameworkTest/Math/Matrix3x2Test.cpp
@@ -200,3 +200,14 @@ TEST(Matrix3x2, CreateSkew)
     EXPECT_EQ(0.0f, matrix(2, 0));
     EXPECT_EQ(0.0f, matrix(2, 1));
 }
+
+TEST(Matrix3x2, Data)
+{
+    Matrix3x2 matrix{0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    EXPECT_EQ(0.0f, *(matrix.Data() + 0));
+    EXPECT_EQ(1.0f, *(matrix.Data() + 1));
+    EXPECT_EQ(2.0f, *(matrix.Data() + 2));
+    EXPECT_EQ(3.0f, *(matrix.Data() + 3));
+    EXPECT_EQ(4.0f, *(matrix.Data() + 4));
+    EXPECT_EQ(5.0f, *(matrix.Data() + 5));
+}

--- a/test/FrameworkTest/Math/Matrix3x3Test.cpp
+++ b/test/FrameworkTest/Math/Matrix3x3Test.cpp
@@ -223,3 +223,17 @@ TEST(Matrix3x3, CreateRotationZ)
     EXPECT_EQ(0.0f, matrix(2, 1));
     EXPECT_EQ(1.0f, matrix(2, 2));
 }
+
+TEST(Matrix3x3, Data)
+{
+    Matrix3x3 matrix{0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+    EXPECT_EQ(0.0f, *(matrix.Data() + 0));
+    EXPECT_EQ(1.0f, *(matrix.Data() + 1));
+    EXPECT_EQ(2.0f, *(matrix.Data() + 2));
+    EXPECT_EQ(3.0f, *(matrix.Data() + 3));
+    EXPECT_EQ(4.0f, *(matrix.Data() + 4));
+    EXPECT_EQ(5.0f, *(matrix.Data() + 5));
+    EXPECT_EQ(6.0f, *(matrix.Data() + 6));
+    EXPECT_EQ(7.0f, *(matrix.Data() + 7));
+    EXPECT_EQ(8.0f, *(matrix.Data() + 8));
+}

--- a/test/FrameworkTest/Math/Matrix4x4Test.cpp
+++ b/test/FrameworkTest/Math/Matrix4x4Test.cpp
@@ -270,3 +270,29 @@ TEST(Matrix4x4, CreateRotationZ)
     EXPECT_EQ(0.0f, matrix(3, 2));
     EXPECT_EQ(1.0f, matrix(3, 3));
 }
+
+TEST(Matrix4x4, Data)
+{
+    Matrix4x4 matrix {
+        0.0f, 1.0f, 2.0f, 3.0f,
+        4.0f, 5.0f, 6.0f, 7.0f,
+        8.0f, 9.0f, 10.0f, 11.0f,
+        12.0f, 13.0f, 14.0f, 15.0f
+    };
+    EXPECT_EQ(0.0f, *(matrix.Data() + 0));
+    EXPECT_EQ(1.0f, *(matrix.Data() + 1));
+    EXPECT_EQ(2.0f, *(matrix.Data() + 2));
+    EXPECT_EQ(3.0f, *(matrix.Data() + 3));
+    EXPECT_EQ(4.0f, *(matrix.Data() + 4));
+    EXPECT_EQ(5.0f, *(matrix.Data() + 5));
+    EXPECT_EQ(6.0f, *(matrix.Data() + 6));
+    EXPECT_EQ(7.0f, *(matrix.Data() + 7));
+    EXPECT_EQ(8.0f, *(matrix.Data() + 8));
+    EXPECT_EQ(9.0f, *(matrix.Data() + 9));
+    EXPECT_EQ(10.0f, *(matrix.Data() + 10));
+    EXPECT_EQ(11.0f, *(matrix.Data() + 11));
+    EXPECT_EQ(12.0f, *(matrix.Data() + 12));
+    EXPECT_EQ(13.0f, *(matrix.Data() + 13));
+    EXPECT_EQ(14.0f, *(matrix.Data() + 14));
+    EXPECT_EQ(15.0f, *(matrix.Data() + 15));
+}


### PR DESCRIPTION
I get the following compiler errors when building on Ubuntu 18.04 with Clang 5.0 and libc++-dev:

```
../src/Math/detail/FloatingPointMatrix3x3.cpp:327:22: error: too many arguments provided to function-like macro invocation
            minor(s, t) = m[i][j];
                     ^
/usr/include/x86_64-linux-gnu/sys/sysmacros.h:102:10: note: macro 'minor' defined here
# define minor(dev) __SYSMACROS_DM (minor) gnu_dev_minor (dev)
         ^
../src/Math/detail/FloatingPointMatrix3x3.cpp:327:25: error: no viable overloaded '='
            minor(s, t) = m[i][j];
            ~~~~~       ^ ~~~~~~~
../src/Math/detail/FloatingPointMatrix3x3.cpp:646:16: note: in instantiation of member function 'Pomdog::Detail::FloatingPointMatrix3x3<float>::Minor2x2' requested here
template class FloatingPointMatrix3x3<float>;
               ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'const std::__1::array<float, 3>::value_type' (aka 'const float') to 'const Pomdog::Detail::FloatingPointMatrix2x2<float>' for 1st argument
class POMDOG_EXPORT FloatingPointMatrix2x2 {
                    ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'const std::__1::array<float, 3>::value_type' (aka 'const float') to 'Pomdog::Detail::FloatingPointMatrix2x2<float>' for 1st argument
../src/Math/detail/FloatingPointMatrix3x3.cpp:327:25: error: no viable overloaded '='
            minor(s, t) = m[i][j];
            ~~~~~       ^ ~~~~~~~
../src/Math/detail/FloatingPointMatrix3x3.cpp:652:16: note: in instantiation of member function 'Pomdog::Detail::FloatingPointMatrix3x3<double>::Minor2x2' requested here
template class FloatingPointMatrix3x3<double>;
               ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'const std::__1::array<double, 3>::value_type' (aka 'const double') to 'const Pomdog::Detail::FloatingPointMatrix2x2<double>' for 1st argument
class POMDOG_EXPORT FloatingPointMatrix2x2 {
                    ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'const std::__1::array<double, 3>::value_type' (aka 'const double') to 'Pomdog::Detail::FloatingPointMatrix2x2<double>' for 1st argument
../src/Math/detail/FloatingPointMatrix3x3.cpp:327:25: error: no viable overloaded '='
            minor(s, t) = m[i][j];
            ~~~~~       ^ ~~~~~~~
../src/Math/detail/FloatingPointMatrix3x3.cpp:659:16: note: in instantiation of member function 'Pomdog::Detail::FloatingPointMatrix3x3<long double>::Minor2x2' requested here
template class FloatingPointMatrix3x3<long double>;
               ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'const std::__1::array<long double, 3>::value_type' (aka 'const long double') to 'const Pomdog::Detail::FloatingPointMatrix2x2<long double>' for 1st argument
class POMDOG_EXPORT FloatingPointMatrix2x2 {
                    ^
../include/Pomdog/Math/detail/FloatingPointMatrix2x2.hpp:16:21: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'const std::__1::array<long double, 3>::value_type' (aka 'const long double') to 'Pomdog::Detail::FloatingPointMatrix2x2<long double>' for 1st argument
4 errors generated.
```

These errors are caused by `#include <array>`, also the elements of Matrix2x2, Matrix3x2, Matrix3x3 and Matrix4x4 are defined using `std::array<>`. So this pull request replaces `std::array<>` with raw arrays and fixes the errors.