### PR TITLE
Add gamepad support for Linux and Mac

### DIFF
--- a/build/pomdog.gyp
+++ b/build/pomdog.gyp
@@ -268,6 +268,10 @@
       '../src/Graphics/ShaderCompilers/HLSLCompiler.cpp',
       '../src/Graphics/ShaderCompilers/MetalCompiler.cpp',
       '../src/Input/KeyboardState.cpp',
+      '../src/InputSystem/GamepadHelper.cpp',
+      '../src/InputSystem/GamepadHelper.hpp',
+      '../src/InputSystem/GamepadMappings.cpp',
+      '../src/InputSystem/GamepadMappings.hpp',
       '../src/InputSystem/InputDeviceCreator.hpp',
       '../src/InputSystem/InputDeviceFactory.cpp',
       '../src/InputSystem/InputDeviceFactory.hpp',
@@ -565,6 +569,7 @@
       '../dependencies/libpng',
       '../dependencies/vendor/libpng',
       '../dependencies/vendor/giflib/lib',
+      '../dependencies/vendor/SDL_GameControllerDB',
     ],
     'sources': [
       '<@(pomdog_library_core_sources)',

--- a/build/pomdog.gyp
+++ b/build/pomdog.gyp
@@ -268,6 +268,8 @@
       '../src/Graphics/ShaderCompilers/HLSLCompiler.cpp',
       '../src/Graphics/ShaderCompilers/MetalCompiler.cpp',
       '../src/Input/KeyboardState.cpp',
+      '../src/InputSystem/GamepadFactory.cpp',
+      '../src/InputSystem/GamepadFactory.hpp',
       '../src/InputSystem/GamepadHelper.cpp',
       '../src/InputSystem/GamepadHelper.hpp',
       '../src/InputSystem/GamepadMappings.cpp',

--- a/build/pomdog.gyp
+++ b/build/pomdog.gyp
@@ -14,7 +14,7 @@
         'application_platform%': 'Cocoa',
         'renderers%': ['GL4'],
         'audio%': 'OpenAL',
-        'input_devices%': [],
+        'input_devices%': ['IOKit'],
       },
     }],
     ['OS == "ios"', {
@@ -446,6 +446,10 @@
       '../src/Platform.Apple/TimeSourceApple.cpp',
       '../src/Platform.Apple/TimeSourceApple.hpp',
     ],
+    'pomdog_library_iokit_sources': [
+      '../src/InputSystem.IOKit/GamepadIOKit.cpp',
+      '../src/InputSystem.IOKit/GamepadIOKit.hpp',
+    ],
     'pomdog_library_cocoa_sources': [
       '../include/Pomdog/Platform/Cocoa/Bootstrap.hpp',
       '../include/Pomdog/Platform/Cocoa/PomdogOpenGLView.hpp',
@@ -740,6 +744,16 @@
           ],
         },
       }], # audio == "XAudio2"
+      ['"IOKit" in input_devices', {
+        'sources': [
+          '<@(pomdog_library_iokit_sources)',
+        ],
+        'link_settings': {
+          'libraries': [
+            '$(SDKROOT)/System/Library/Frameworks/IOKit.framework',
+          ],
+        },
+      }],
       ['"DirectInput" in input_devices', {
         'sources': [
           '<@(pomdog_library_directinput_sources)',

--- a/build/pomdog.gyp
+++ b/build/pomdog.gyp
@@ -30,7 +30,7 @@
         'application_platform%': 'X11',
         'renderers%': ['GL4'],
         'audio%': 'OpenAL',
-        'input_devices%': [],
+        'input_devices%': ['Linux'],
       },
     }],
   ],
@@ -275,6 +275,7 @@
       '../src/InputSystem/InputDeviceCreator.hpp',
       '../src/InputSystem/InputDeviceFactory.cpp',
       '../src/InputSystem/InputDeviceFactory.hpp',
+      '../src/InputSystem/NativeGamepad.hpp',
       '../src/Logging/Log.cpp',
       '../src/Logging/LogChannel.cpp',
       '../src/Math/BoundingBox.cpp',
@@ -558,6 +559,10 @@
       '../src/Platform.Linux/TimeSourceLinux.cpp',
       '../src/Platform.Linux/TimeSourceLinux.hpp',
     ],
+    'pomdog_library_input_linux_sources': [
+      '../src/InputSystem.Linux/GamepadLinux.cpp',
+      '../src/InputSystem.Linux/GamepadLinux.hpp',
+    ],
   },
   'target_defaults': {
     'dependencies': [
@@ -745,6 +750,11 @@
             '-ldxguid.lib',
           ],
         },
+      }],
+      ['"Linux" in input_devices', {
+        'sources': [
+          '<@(pomdog_library_input_linux_sources)',
+        ],
       }],
       ['application_platform == "X11"', {
         'sources': [

--- a/build/pomdog.xcodeproj/project.pbxproj
+++ b/build/pomdog.xcodeproj/project.pbxproj
@@ -198,6 +198,10 @@
 		A9D641931C343023006E14E0 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB039FAE65C607A60DDBB49C /* OpenGL.framework */; };
 		A9D641941C34302C006E14E0 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F247CD851F16A8BCEC2E5BA1 /* Cocoa.framework */; };
 		A9D641951C343034006E14E0 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0AE4521498F69CE846F2EFB /* QuartzCore.framework */; };
+		A9E4B86A210CD9C1003F87DC /* GamepadMappings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */; };
+		A9E4B86B210CD9C1003F87DC /* GamepadMappings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */; };
+		A9E4B86C210CD9C1003F87DC /* GamepadHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */; };
+		A9E4B86D210CD9C1003F87DC /* GamepadHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */; };
 		A9F2135A1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135B1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135D1DE35F420027FA45 /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F2135C1DE35F420027FA45 /* Plane.cpp */; };
@@ -610,6 +614,10 @@
 		A9AE680DD0E3FCEA11AF8F48 /* FloatingPointVector4.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FloatingPointVector4.cpp; sourceTree = "<group>"; };
 		A9D18E8B1CA426FA0011A6CE /* MetalCompiler.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MetalCompiler.hpp; sourceTree = "<group>"; };
 		A9D18E8C1CA427270011A6CE /* MetalCompiler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MetalCompiler.cpp; sourceTree = "<group>"; };
+		A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadMappings.cpp; sourceTree = "<group>"; };
+		A9E4B867210CD9C0003F87DC /* GamepadMappings.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadMappings.hpp; sourceTree = "<group>"; };
+		A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadHelper.cpp; sourceTree = "<group>"; };
+		A9E4B869210CD9C0003F87DC /* GamepadHelper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadHelper.hpp; sourceTree = "<group>"; };
 		A9F213561DE35F1B0027FA45 /* BoundingFrustum.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BoundingFrustum.hpp; sourceTree = "<group>"; };
 		A9F213571DE35F260027FA45 /* Plane.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Plane.hpp; sourceTree = "<group>"; };
 		A9F213581DE35F260027FA45 /* PlaneIntersectionType.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PlaneIntersectionType.hpp; sourceTree = "<group>"; };
@@ -918,6 +926,10 @@
 		34C6330F2DF6F100237B8429 /* InputSystem */ = {
 			isa = PBXGroup;
 			children = (
+				A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */,
+				A9E4B869210CD9C0003F87DC /* GamepadHelper.hpp */,
+				A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */,
+				A9E4B867210CD9C0003F87DC /* GamepadMappings.hpp */,
 				1C7CBAD3B25BA6B0D155A5E6 /* InputDeviceCreator.hpp */,
 				B7379F84C54E861AD074AA1C /* InputDeviceFactory.cpp */,
 				5672D00947C663520B460134 /* InputDeviceFactory.hpp */,
@@ -1884,6 +1896,7 @@
 				C0B84A37FCB13D340E04120C /* Connection.cpp in Sources */,
 				DD35FD410F3B10D3D7108DD5 /* ConnectionList.cpp in Sources */,
 				162657EF7F7D8D1E34C76882 /* EventQueue.cpp in Sources */,
+				A9E4B86A210CD9C1003F87DC /* GamepadMappings.cpp in Sources */,
 				A9A822931DAB7FBE0091497F /* TextureAtlasGenerator.cpp in Sources */,
 				A9FC99051DC3D87F00C78D63 /* SpriteBatch.cpp in Sources */,
 				9439AAF08FDF6A7046F2F994 /* ScopedConnection.cpp in Sources */,
@@ -1899,6 +1912,7 @@
 				A997F6FE1CAEFC4800926392 /* MetalFormatHelper.mm in Sources */,
 				A93CA6541D92F34E00B65171 /* Task.cpp in Sources */,
 				A992AF041C2B1168003170C9 /* Coordinate3D.cpp in Sources */,
+				A9E4B86C210CD9C1003F87DC /* GamepadHelper.cpp in Sources */,
 				A997F6F61CAEFC4800926392 /* BufferMetal.mm in Sources */,
 				D036ADDD0CD6E4CE27AC1A93 /* GraphicsContextGL4.cpp in Sources */,
 				74D477E9B36CBB96B59576DA /* GraphicsDeviceGL4.cpp in Sources */,
@@ -2008,6 +2022,7 @@
 				B8B5DF3E58503D84B8D7E2D9 /* Connection.cpp in Sources */,
 				48657AD97E278FA04C4994B4 /* ConnectionList.cpp in Sources */,
 				5D895FC546DFD02F64646AF7 /* EventQueue.cpp in Sources */,
+				A9E4B86B210CD9C1003F87DC /* GamepadMappings.cpp in Sources */,
 				A9A822941DAB7FBE0091497F /* TextureAtlasGenerator.cpp in Sources */,
 				A9FC99061DC3D87F00C78D63 /* SpriteBatch.cpp in Sources */,
 				023F583DEDA9BCB1C9E19C1C /* ScopedConnection.cpp in Sources */,
@@ -2023,6 +2038,7 @@
 				A997F6FF1CAEFC4800926392 /* MetalFormatHelper.mm in Sources */,
 				A93CA6551D92F34E00B65171 /* Task.cpp in Sources */,
 				A992AF051C2B1168003170C9 /* Coordinate3D.cpp in Sources */,
+				A9E4B86D210CD9C1003F87DC /* GamepadHelper.cpp in Sources */,
 				A997F6F71CAEFC4800926392 /* BufferMetal.mm in Sources */,
 				C7615C67C153671C670F649B /* GraphicsContextGL4.cpp in Sources */,
 				FD3FD836F0346B587EDB61DE /* GraphicsDeviceGL4.cpp in Sources */,
@@ -2192,6 +2208,7 @@
 					../dependencies/libpng,
 					../dependencies/vendor/libpng,
 					../dependencies/vendor/giflib/lib,
+					../dependencies/vendor/SDL_GameControllerDB,
 				);
 			};
 			name = Release;
@@ -2270,6 +2287,7 @@
 					../dependencies/libpng,
 					../dependencies/vendor/libpng,
 					../dependencies/vendor/giflib/lib,
+					../dependencies/vendor/SDL_GameControllerDB,
 				);
 				ONLY_ACTIVE_ARCH = YES;
 			};

--- a/build/pomdog.xcodeproj/project.pbxproj
+++ b/build/pomdog.xcodeproj/project.pbxproj
@@ -618,6 +618,7 @@
 		A9E4B867210CD9C0003F87DC /* GamepadMappings.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadMappings.hpp; sourceTree = "<group>"; };
 		A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadHelper.cpp; sourceTree = "<group>"; };
 		A9E4B869210CD9C0003F87DC /* GamepadHelper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadHelper.hpp; sourceTree = "<group>"; };
+		A9E4B86E210CDCC7003F87DC /* NativeGamepad.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NativeGamepad.hpp; sourceTree = "<group>"; };
 		A9F213561DE35F1B0027FA45 /* BoundingFrustum.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BoundingFrustum.hpp; sourceTree = "<group>"; };
 		A9F213571DE35F260027FA45 /* Plane.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Plane.hpp; sourceTree = "<group>"; };
 		A9F213581DE35F260027FA45 /* PlaneIntersectionType.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PlaneIntersectionType.hpp; sourceTree = "<group>"; };
@@ -933,6 +934,7 @@
 				1C7CBAD3B25BA6B0D155A5E6 /* InputDeviceCreator.hpp */,
 				B7379F84C54E861AD074AA1C /* InputDeviceFactory.cpp */,
 				5672D00947C663520B460134 /* InputDeviceFactory.hpp */,
+				A9E4B86E210CDCC7003F87DC /* NativeGamepad.hpp */,
 			);
 			path = InputSystem;
 			sourceTree = "<group>";

--- a/build/pomdog.xcodeproj/project.pbxproj
+++ b/build/pomdog.xcodeproj/project.pbxproj
@@ -206,6 +206,8 @@
 		A9E4B873210CDDEB003F87DC /* GamepadIOKit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */; };
 		A9E4B875210CDE03003F87DC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E4B874210CDE03003F87DC /* IOKit.framework */; };
 		A9E4B876210CDE12003F87DC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E4B874210CDE03003F87DC /* IOKit.framework */; };
+		A9E4B879210CDEA2003F87DC /* GamepadFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B877210CDEA2003F87DC /* GamepadFactory.cpp */; };
+		A9E4B87A210CDEA2003F87DC /* GamepadFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B877210CDEA2003F87DC /* GamepadFactory.cpp */; };
 		A9F2135A1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135B1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135D1DE35F420027FA45 /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F2135C1DE35F420027FA45 /* Plane.cpp */; };
@@ -626,6 +628,8 @@
 		A9E4B870210CDDEB003F87DC /* GamepadIOKit.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = GamepadIOKit.hpp; path = ../InputSystem.IOKit/GamepadIOKit.hpp; sourceTree = "<group>"; };
 		A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GamepadIOKit.cpp; path = ../InputSystem.IOKit/GamepadIOKit.cpp; sourceTree = "<group>"; };
 		A9E4B874210CDE03003F87DC /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		A9E4B877210CDEA2003F87DC /* GamepadFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadFactory.cpp; sourceTree = "<group>"; };
+		A9E4B878210CDEA2003F87DC /* GamepadFactory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadFactory.hpp; sourceTree = "<group>"; };
 		A9F213561DE35F1B0027FA45 /* BoundingFrustum.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BoundingFrustum.hpp; sourceTree = "<group>"; };
 		A9F213571DE35F260027FA45 /* Plane.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Plane.hpp; sourceTree = "<group>"; };
 		A9F213581DE35F260027FA45 /* PlaneIntersectionType.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PlaneIntersectionType.hpp; sourceTree = "<group>"; };
@@ -936,6 +940,8 @@
 		34C6330F2DF6F100237B8429 /* InputSystem */ = {
 			isa = PBXGroup;
 			children = (
+				A9E4B877210CDEA2003F87DC /* GamepadFactory.cpp */,
+				A9E4B878210CDEA2003F87DC /* GamepadFactory.hpp */,
 				A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */,
 				A9E4B869210CD9C0003F87DC /* GamepadHelper.hpp */,
 				A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */,
@@ -1924,6 +1930,7 @@
 				A9A822931DAB7FBE0091497F /* TextureAtlasGenerator.cpp in Sources */,
 				A9FC99051DC3D87F00C78D63 /* SpriteBatch.cpp in Sources */,
 				9439AAF08FDF6A7046F2F994 /* ScopedConnection.cpp in Sources */,
+				A9E4B879210CDEA2003F87DC /* GamepadFactory.cpp in Sources */,
 				8650CF18F26DB3A0F89ABAE3 /* CRC32.cpp in Sources */,
 				A997F7081CAEFC4900926392 /* Texture2DMetal.mm in Sources */,
 				566D366B6621FECC73232526 /* PathHelper.cpp in Sources */,
@@ -2051,6 +2058,7 @@
 				A9A822941DAB7FBE0091497F /* TextureAtlasGenerator.cpp in Sources */,
 				A9FC99061DC3D87F00C78D63 /* SpriteBatch.cpp in Sources */,
 				023F583DEDA9BCB1C9E19C1C /* ScopedConnection.cpp in Sources */,
+				A9E4B87A210CDEA2003F87DC /* GamepadFactory.cpp in Sources */,
 				65B8BEF3D1E04BF859631ADE /* CRC32.cpp in Sources */,
 				A997F7091CAEFC4900926392 /* Texture2DMetal.mm in Sources */,
 				8B19A1DD45CD8F8791C5B725 /* PathHelper.cpp in Sources */,

--- a/build/pomdog.xcodeproj/project.pbxproj
+++ b/build/pomdog.xcodeproj/project.pbxproj
@@ -202,6 +202,10 @@
 		A9E4B86B210CD9C1003F87DC /* GamepadMappings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B866210CD9C0003F87DC /* GamepadMappings.cpp */; };
 		A9E4B86C210CD9C1003F87DC /* GamepadHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */; };
 		A9E4B86D210CD9C1003F87DC /* GamepadHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */; };
+		A9E4B872210CDDEB003F87DC /* GamepadIOKit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */; };
+		A9E4B873210CDDEB003F87DC /* GamepadIOKit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */; };
+		A9E4B875210CDE03003F87DC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E4B874210CDE03003F87DC /* IOKit.framework */; };
+		A9E4B876210CDE12003F87DC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E4B874210CDE03003F87DC /* IOKit.framework */; };
 		A9F2135A1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135B1DE35F380027FA45 /* BoundingFrustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F213591DE35F380027FA45 /* BoundingFrustum.cpp */; };
 		A9F2135D1DE35F420027FA45 /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9F2135C1DE35F420027FA45 /* Plane.cpp */; };
@@ -619,6 +623,9 @@
 		A9E4B868210CD9C0003F87DC /* GamepadHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GamepadHelper.cpp; sourceTree = "<group>"; };
 		A9E4B869210CD9C0003F87DC /* GamepadHelper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = GamepadHelper.hpp; sourceTree = "<group>"; };
 		A9E4B86E210CDCC7003F87DC /* NativeGamepad.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NativeGamepad.hpp; sourceTree = "<group>"; };
+		A9E4B870210CDDEB003F87DC /* GamepadIOKit.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = GamepadIOKit.hpp; path = ../InputSystem.IOKit/GamepadIOKit.hpp; sourceTree = "<group>"; };
+		A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GamepadIOKit.cpp; path = ../InputSystem.IOKit/GamepadIOKit.cpp; sourceTree = "<group>"; };
+		A9E4B874210CDE03003F87DC /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		A9F213561DE35F1B0027FA45 /* BoundingFrustum.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BoundingFrustum.hpp; sourceTree = "<group>"; };
 		A9F213571DE35F260027FA45 /* Plane.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Plane.hpp; sourceTree = "<group>"; };
 		A9F213581DE35F260027FA45 /* PlaneIntersectionType.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PlaneIntersectionType.hpp; sourceTree = "<group>"; };
@@ -751,6 +758,7 @@
 				A9D641871C342F5F006E14E0 /* libzlib.a in Frameworks */,
 				A997F6DF1CAEFB3E00926392 /* AudioToolbox.framework in Frameworks */,
 				A9D641941C34302C006E14E0 /* Cocoa.framework in Frameworks */,
+				A9E4B875210CDE03003F87DC /* IOKit.framework in Frameworks */,
 				A997F6DC1CAEFB0800926392 /* Metal.framework in Frameworks */,
 				A9D641921C34301C006E14E0 /* OpenAL.framework in Frameworks */,
 				A9D641931C343023006E14E0 /* OpenGL.framework in Frameworks */,
@@ -767,6 +775,7 @@
 				4D3F6C1E105B1A1149475635 /* libzlib.a in Frameworks */,
 				A997F6E01CAEFB4900926392 /* AudioToolbox.framework in Frameworks */,
 				667D66568DF02EFA74F073DE /* Cocoa.framework in Frameworks */,
+				A9E4B876210CDE12003F87DC /* IOKit.framework in Frameworks */,
 				A997F6DD1CAEFB1800926392 /* Metal.framework in Frameworks */,
 				BECB75C4B0471C4F7255D067 /* OpenAL.framework in Frameworks */,
 				3731B1EE2512BA451CA8E5D7 /* OpenGL.framework in Frameworks */,
@@ -1023,6 +1032,7 @@
 				C75D42DC2FCD94A2C16953DC /* Graphics */,
 				A4530A8C4CEA403D2E7D71ED /* Input */,
 				34C6330F2DF6F100237B8429 /* InputSystem */,
+				A9E4B86F210CDDB9003F87DC /* InputSystem.IOKit */,
 				6A0441A5D4CDAD2C95CF69B3 /* Logging */,
 				2694DA612683E85FCA7EC307 /* Math */,
 				D0E09111DB852231F1413898 /* Platform.Apple */,
@@ -1430,6 +1440,16 @@
 			path = TexturePacker;
 			sourceTree = "<group>";
 		};
+		A9E4B86F210CDDB9003F87DC /* InputSystem.IOKit */ = {
+			isa = PBXGroup;
+			children = (
+				A9E4B871210CDDEB003F87DC /* GamepadIOKit.cpp */,
+				A9E4B870210CDDEB003F87DC /* GamepadIOKit.hpp */,
+			);
+			name = InputSystem.IOKit;
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		A9FC99031DC3D86C00C78D63 /* Graphics */ = {
 			isa = PBXGroup;
 			children = (
@@ -1648,6 +1668,7 @@
 		E5BCF0B13AAAF8E1F45AEBD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A9E4B874210CDE03003F87DC /* IOKit.framework */,
 				A997F6DE1CAEFB3E00926392 /* AudioToolbox.framework */,
 				F247CD851F16A8BCEC2E5BA1 /* Cocoa.framework */,
 				A997F6DB1CAEFB0800926392 /* Metal.framework */,
@@ -1830,6 +1851,7 @@
 				A997F7041CAEFC4900926392 /* SamplerStateMetal.mm in Sources */,
 				B7E9DD7713CD0E5323210193 /* AudioEngine.cpp in Sources */,
 				A9A8228F1DAB7FB70091497F /* Image.cpp in Sources */,
+				A9E4B872210CDDEB003F87DC /* GamepadIOKit.cpp in Sources */,
 				A997F7001CAEFC4800926392 /* PipelineStateMetal.mm in Sources */,
 				B25BC69FDA812635B36D2CAC /* SoundEffect.cpp in Sources */,
 				5F8F4C5C0179D8889EC7B4D2 /* AssetDictionary.cpp in Sources */,
@@ -1956,6 +1978,7 @@
 				A997F7051CAEFC4900926392 /* SamplerStateMetal.mm in Sources */,
 				3EB59864165741842C8DD788 /* AudioEngine.cpp in Sources */,
 				A9A822901DAB7FB70091497F /* Image.cpp in Sources */,
+				A9E4B873210CDDEB003F87DC /* GamepadIOKit.cpp in Sources */,
 				A997F7011CAEFC4800926392 /* PipelineStateMetal.mm in Sources */,
 				615FEBD97D48A4D57BDA54C4 /* SoundEffect.cpp in Sources */,
 				E4D0DB6D0CBC0C51449C182B /* AssetDictionary.cpp in Sources */,

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -30,6 +30,7 @@ source_group(Utility                  REGULAR_EXPRESSION "(include/Pomdog|src)/U
 source_group(Application              REGULAR_EXPRESSION "(include/Pomdog|src)/Application/*")
 source_group(InputSystem              REGULAR_EXPRESSION src/InputSystem/*)
 source_group(InputSystem.DirectInput  REGULAR_EXPRESSION src/InputSystem.DirectInput/*)
+source_group(InputSystem.Linux        REGULAR_EXPRESSION src/InputSystem.Linux/*)
 source_group(Platform.Apple           REGULAR_EXPRESSION src/Platform.Apple/*)
 source_group(Platform.Linux           REGULAR_EXPRESSION src/Platform.Linux/*)
 source_group(RenderSystem             REGULAR_EXPRESSION src/RenderSystem/*)
@@ -282,6 +283,7 @@ set(POMDOG_SOURCES_CORE
   ${POMDOG_DIR}/src/InputSystem/InputDeviceCreator.hpp
   ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.cpp
   ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.hpp
+  ${POMDOG_DIR}/src/InputSystem/NativeGamepad.hpp
   ${POMDOG_DIR}/src/Logging/Log.cpp
   ${POMDOG_DIR}/src/Logging/LogChannel.cpp
   ${POMDOG_DIR}/src/Math/BoundingBox.cpp
@@ -556,6 +558,8 @@ set(POMDOG_SOURCES_X11
 )
 
 set(POMDOG_SOURCES_LINUX
+  ${POMDOG_DIR}/src/InputSystem.Linux/GamepadLinux.cpp
+  ${POMDOG_DIR}/src/InputSystem.Linux/GamepadLinux.hpp
   ${POMDOG_DIR}/src/Platform.Linux/FileSystemLinux.cpp
   ${POMDOG_DIR}/src/Platform.Linux/TimeSourceLinux.cpp
   ${POMDOG_DIR}/src/Platform.Linux/TimeSourceLinux.hpp

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -277,6 +277,8 @@ set(POMDOG_SOURCES_CORE
   ${POMDOG_DIR}/src/Graphics/ShaderCompilers/HLSLCompiler.cpp
   ${POMDOG_DIR}/src/Graphics/ShaderCompilers/MetalCompiler.cpp
   ${POMDOG_DIR}/src/Input/KeyboardState.cpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadFactory.cpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadFactory.hpp
   ${POMDOG_DIR}/src/InputSystem/GamepadHelper.cpp
   ${POMDOG_DIR}/src/InputSystem/GamepadHelper.hpp
   ${POMDOG_DIR}/src/InputSystem/GamepadMappings.cpp

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -30,6 +30,7 @@ source_group(Utility                  REGULAR_EXPRESSION "(include/Pomdog|src)/U
 source_group(Application              REGULAR_EXPRESSION "(include/Pomdog|src)/Application/*")
 source_group(InputSystem              REGULAR_EXPRESSION src/InputSystem/*)
 source_group(InputSystem.DirectInput  REGULAR_EXPRESSION src/InputSystem.DirectInput/*)
+source_group(InputSystem.IOKit        REGULAR_EXPRESSION src/InputSystem.IOKit/*)
 source_group(InputSystem.Linux        REGULAR_EXPRESSION src/InputSystem.Linux/*)
 source_group(Platform.Apple           REGULAR_EXPRESSION src/Platform.Apple/*)
 source_group(Platform.Linux           REGULAR_EXPRESSION src/Platform.Linux/*)
@@ -416,6 +417,11 @@ set(POMDOG_SOURCES_COCOA
   ${POMDOG_DIR}/src/Platform.Cocoa/PomdogOpenGLView.mm
 )
 
+set(POMDOG_SOURCES_IOKIT
+  ${POMDOG_DIR}/src/InputSystem.IOKit/GamepadIOKit.cpp
+  ${POMDOG_DIR}/src/InputSystem.IOKit/GamepadIOKit.hpp
+)
+
 set(POMDOG_SOURCES_DIRECT3D
   ${POMDOG_DIR}/src/RenderSystem.DXGI/DXGIFormatHelper.cpp
   ${POMDOG_DIR}/src/RenderSystem.DXGI/DXGIFormatHelper.hpp
@@ -576,6 +582,7 @@ if(APPLE)
   set(POMDOG_USE_OPENAL      true    CACHE BOOL   "Use OpenAL")
   set(POMDOG_USE_XAUDIO2     false   CACHE BOOL   "Use XAudio2")
   set(POMDOG_USE_DIRECTINPUT false   CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_IOKIT       true    CACHE BOOL   "Use IOKit")
   set(POMDOG_USE_X11         false   CACHE BOOL   "Use X11")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(POMDOG_TARGET_PLATFORM "Linux" CACHE STRING "Choose platform")
@@ -586,6 +593,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(POMDOG_USE_OPENAL      true    CACHE BOOL   "Use OpenAL")
   set(POMDOG_USE_XAUDIO2     false   CACHE BOOL   "Use XAudio2")
   set(POMDOG_USE_DIRECTINPUT false   CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_IOKIT       false   CACHE BOOL   "Use IOKit")
   set(POMDOG_USE_X11         true    CACHE BOOL   "Use X11")
 elseif(WIN32)
   set(POMDOG_TARGET_PLATFORM "Win32" CACHE STRING "Choose platform")
@@ -596,6 +604,7 @@ elseif(WIN32)
   set(POMDOG_USE_OPENAL      false   CACHE BOOL   "Use OpenAL")
   set(POMDOG_USE_XAUDIO2     true    CACHE BOOL   "Use XAudio2")
   set(POMDOG_USE_DIRECTINPUT true    CACHE BOOL   "Use DirectInput")
+  set(POMDOG_USE_IOKIT       false   CACHE BOOL   "Use IOKit")
   set(POMDOG_USE_X11         false   CACHE BOOL   "Use X11")
 endif()
 
@@ -642,6 +651,10 @@ if(POMDOG_USE_X11)
   list(APPEND SOURCE_FILES ${POMDOG_SOURCES_X11})
 endif()
 
+if(POMDOG_USE_IOKIT)
+  list(APPEND SOURCE_FILES ${POMDOG_SOURCES_IOKIT})
+endif()
+
 # NOTE: Linking libraries for Mac and Xcode
 if(POMDOG_USE_METAL)
   # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/Metal.framework")
@@ -653,6 +666,11 @@ if(POMDOG_USE_OPENAL AND (POMDOG_TARGET_PLATFORM MATCHES "Mac"))
   # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/OpenAL.framework")
   set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework AudioToolBox")
   set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenAL")
+endif()
+
+if(POMDOG_USE_IOKIT AND (POMDOG_TARGET_PLATFORM MATCHES "Mac"))
+  # list(APPEND LINK_FRAMEWORKS "$(SDKROOT)/System/Library/Frameworks/IOKit.framework")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework IOKit")
 endif()
 
 if(POMDOG_TARGET_PLATFORM MATCHES "Mac")

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -275,6 +275,10 @@ set(POMDOG_SOURCES_CORE
   ${POMDOG_DIR}/src/Graphics/ShaderCompilers/HLSLCompiler.cpp
   ${POMDOG_DIR}/src/Graphics/ShaderCompilers/MetalCompiler.cpp
   ${POMDOG_DIR}/src/Input/KeyboardState.cpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadHelper.cpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadHelper.hpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadMappings.cpp
+  ${POMDOG_DIR}/src/InputSystem/GamepadMappings.hpp
   ${POMDOG_DIR}/src/InputSystem/InputDeviceCreator.hpp
   ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.cpp
   ${POMDOG_DIR}/src/InputSystem/InputDeviceFactory.hpp
@@ -664,6 +668,7 @@ target_include_directories(${PRODUCT_NAME} PRIVATE
   ${POMDOG_DIR}/include
   ${POMDOG_DIR}/dependencies/libpng
   ${POMDOG_DIR}/dependencies/vendor/libpng
+  ${POMDOG_DIR}/dependencies/vendor/SDL_GameControllerDB
 )
 
 add_subdirectory(${POMDOG_DIR}/build/dependencies/libpng "${CMAKE_CURRENT_BINARY_DIR}/libpng_build")

--- a/examples/QuickStart/CMakeLists.txt
+++ b/examples/QuickStart/CMakeLists.txt
@@ -121,6 +121,7 @@ if(APPLE)
   set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework OpenAL")
   set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework Cocoa")
   set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework QuartzCore")
+  set(LINK_FRAMEWORKS "${LINK_FRAMEWORKS} -framework IOKit")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINK_FRAMEWORKS}")
 endif()
 

--- a/include/Pomdog/Application/GameHost.hpp
+++ b/include/Pomdog/Application/GameHost.hpp
@@ -11,6 +11,7 @@ namespace Pomdog {
 class AssetManager;
 class AudioEngine;
 class GameClock;
+class Gamepad;
 class GameWindow;
 class GraphicsCommandQueue;
 class GraphicsDevice;
@@ -42,6 +43,8 @@ public:
     virtual std::shared_ptr<Keyboard> GetKeyboard() = 0;
 
     virtual std::shared_ptr<Mouse> GetMouse() = 0;
+
+    virtual std::shared_ptr<Gamepad> GetGamepad() = 0;
 
     virtual SurfaceFormat GetBackBufferSurfaceFormat() const = 0;
 

--- a/include/Pomdog/Input/Gamepad.hpp
+++ b/include/Pomdog/Input/Gamepad.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Pomdog/Basic/Export.hpp"
+#include "Pomdog/Input/PlayerIndex.hpp"
 
 namespace Pomdog {
 
@@ -13,9 +14,9 @@ class POMDOG_EXPORT Gamepad {
 public:
     virtual ~Gamepad() = default;
 
-    virtual GamepadCapabilities GetCapabilities() const = 0;
+    virtual GamepadCapabilities GetCapabilities(PlayerIndex index) const = 0;
 
-    virtual GamepadState GetState() const = 0;
+    virtual GamepadState GetState(PlayerIndex index) const = 0;
 };
 
 } // namespace Pomdog

--- a/include/Pomdog/Input/GamepadButtons.hpp
+++ b/include/Pomdog/Input/GamepadButtons.hpp
@@ -6,6 +6,19 @@
 
 namespace Pomdog {
 
+// Gamepad's layout:
+//  ----------------------------------------
+//　　　    (L2)                  (R2)    Triggers
+//　　　    (L1)                  (R1)    Shoulders
+//  ---------------------------------------
+//　　　          (LM)     (RM)           Menu Buttons
+//　　　     +       (Guide)      (Y)
+//  DPad  +-+-+                (X) (B)   Buttons
+//　　　     +                    (A)
+//  -----------------------------------------
+//　　　         (LS)       (RS)
+//　  　　 Left Stick       Right Stick
+//  ------------------------------------------
 struct GamepadButtons final {
     ButtonState A = ButtonState::Released;
     ButtonState B = ButtonState::Released;
@@ -13,9 +26,15 @@ struct GamepadButtons final {
     ButtonState Y = ButtonState::Released;
     ButtonState LeftShoulder = ButtonState::Released;
     ButtonState RightShoulder = ButtonState::Released;
-    ButtonState Start = ButtonState::Released;
+    ButtonState LeftTrigger = ButtonState::Released;
+    ButtonState RightTrigger = ButtonState::Released;
+    ButtonState LeftMenu = ButtonState::Released;
+    ButtonState RightMenu = ButtonState::Released;
     ButtonState LeftStick = ButtonState::Released;
     ButtonState RightStick = ButtonState::Released;
+    ButtonState Guide = ButtonState::Released;
+    ButtonState Extra1 = ButtonState::Released;
+    ButtonState Extra2 = ButtonState::Released;
 };
 
 } // namespace Pomdog

--- a/include/Pomdog/Input/GamepadCapabilities.hpp
+++ b/include/Pomdog/Input/GamepadCapabilities.hpp
@@ -3,11 +3,18 @@
 #pragma once
 
 #include "Pomdog/Input/GamepadType.hpp"
+#include <string>
 
 namespace Pomdog {
 
 struct GamepadCapabilities final {
     GamepadType GamepadType = GamepadType::Unknown;
+
+    std::string Name;
+
+    int ButtonCount = 0;
+
+    int ThumbStickCount = 0;
 
     bool IsConnected = false;
 

--- a/src/InputSystem.IOKit/GamepadIOKit.cpp
+++ b/src/InputSystem.IOKit/GamepadIOKit.cpp
@@ -1,0 +1,421 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#include "GamepadIOKit.hpp"
+#include "../InputSystem/GamepadHelper.hpp"
+#include "Pomdog/Logging/Log.hpp"
+#include "Pomdog/Utility/Assert.hpp"
+#include "Pomdog/Utility/Exception.hpp"
+#include <algorithm>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace Apple {
+namespace {
+
+void AppendDeviceMatching(CFMutableArrayRef matcher, uint32_t page, uint32_t usage)
+{
+    auto result = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    if (result == nullptr) {
+        return;
+    }
+
+    auto pageNumber = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &page);
+    CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsagePageKey), pageNumber);
+    CFRelease(pageNumber);
+
+    auto usageNumber = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
+    CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsageKey), usageNumber);
+    CFRelease(usageNumber);
+
+    CFArrayAppendValue(matcher, result);
+    CFRelease(result);
+}
+
+ButtonState GetTriggerButtonValue(IOHIDValueRef valueRef)
+{
+    const auto value = IOHIDValueGetIntegerValue(valueRef);
+    return (value > 0) ? ButtonState::Pressed: ButtonState::Released;
+}
+
+float GetThumbStickValue(IOHIDValueRef valueRef, const ThumbStickInfo& info)
+{
+    const auto value = IOHIDValueGetIntegerValue(valueRef);
+    return (static_cast<float>((value - info.Minimum) * 2 - info.Range) / info.Range);
+}
+
+} // unnamed namespace
+
+void GamepadDevice::Close()
+{
+    if (device != nullptr) {
+        IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+        device = nullptr;
+    }
+
+    GamepadHelper::ClearState(state);
+    state.IsConnected = false;
+
+    caps.Name = "";
+    caps.ThumbStickCount = 0;
+    caps.ButtonCount = 0;
+}
+
+void GamepadDevice::OnDeviceInput(IOReturn result, void* sender, IOHIDValueRef value)
+{
+    const auto element = IOHIDValueGetElement(value);
+    const auto usagePage = IOHIDElementGetUsagePage(element);
+    const auto usage = IOHIDElementGetUsage(element);
+
+    switch (IOHIDElementGetType(element)) {
+    case kIOHIDElementTypeInput_Button: {
+        const auto buttonIndex = static_cast<int>(usage) - 1;
+        if (auto button = GetButton(state, mappings.buttons, buttonIndex); button != nullptr) {
+            (*button) = (IOHIDValueGetIntegerValue(value) != 0)
+                ? ButtonState::Pressed
+                : ButtonState::Released;
+        }
+        break;
+    }
+    case kIOHIDElementTypeInput_Axis:
+    case kIOHIDElementTypeInput_Misc: {
+        switch (usagePage) {
+        case kHIDPage_GenericDesktop: {
+            switch (usage) {
+            case kHIDUsage_GD_X:
+            case kHIDUsage_GD_Y:
+            case kHIDUsage_GD_Z:
+            case kHIDUsage_GD_Rx:
+            case kHIDUsage_GD_Ry:
+            case kHIDUsage_GD_Rz: {
+                const auto thumbStickIndex = static_cast<int>(usage - kHIDUsage_GD_X);
+                POMDOG_ASSERT(thumbStickIndex >= 0);
+                POMDOG_ASSERT(thumbStickIndex < static_cast<int>(mappings.axes.size()));
+                POMDOG_ASSERT(thumbStickIndex < static_cast<int>(thumbStickInfos.size()));
+
+                switch (mappings.axes[thumbStickIndex]) {
+                case AxesKind::LeftTrigger:
+                    state.Buttons.LeftTrigger = GetTriggerButtonValue(value);
+                    break;
+                case AxesKind::RightTrigger:
+                    state.Buttons.RightTrigger = GetTriggerButtonValue(value);
+                    break;
+                case AxesKind::LeftStickX:
+                    state.ThumbSticks.Left.X = GetThumbStickValue(value, thumbStickInfos[thumbStickIndex]);
+                    break;
+                case AxesKind::LeftStickY:
+                    state.ThumbSticks.Left.Y = GetThumbStickValue(value, thumbStickInfos[thumbStickIndex]);
+                    break;
+                case AxesKind::RightStickX:
+                    state.ThumbSticks.Right.X = GetThumbStickValue(value, thumbStickInfos[thumbStickIndex]);
+                    break;
+                case AxesKind::RightStickY:
+                    state.ThumbSticks.Right.Y = GetThumbStickValue(value, thumbStickInfos[thumbStickIndex]);
+                    break;
+                default:
+                    break;
+                }
+                break;
+            }
+            case kHIDUsage_GD_Hatswitch: {
+                // TODO: Need to refactor later.
+                switch (IOHIDValueGetIntegerValue(value)) {
+                case 0:
+                    state.DPad.Up = ButtonState::Pressed;
+                    state.DPad.Right = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Released;
+                    break;
+                case 1:
+                    state.DPad.Up = ButtonState::Pressed;
+                    state.DPad.Right = ButtonState::Pressed;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Released;
+                    break;
+                case 2:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Pressed;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Released;
+                    break;
+                case 3:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Pressed;
+                    state.DPad.Down = ButtonState::Pressed;
+                    state.DPad.Left = ButtonState::Released;
+                    break;
+                case 4:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Pressed;
+                    state.DPad.Left = ButtonState::Released;
+                    break;
+                case 5:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Pressed;
+                    state.DPad.Left = ButtonState::Pressed;
+                    break;
+                case 6:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Pressed;
+                    break;
+                case 7:
+                    state.DPad.Up = ButtonState::Pressed;
+                    state.DPad.Right = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Pressed;
+                    break;
+                case 8:
+                default:
+                    state.DPad.Up = ButtonState::Released;
+                    state.DPad.Down = ButtonState::Released;
+                    state.DPad.Left = ButtonState::Released;
+                    state.DPad.Right = ButtonState::Released;
+                    break;
+                }
+                break;
+            }
+            case kHIDUsage_GD_DPadUp:
+            case kHIDUsage_GD_DPadDown:
+            case kHIDUsage_GD_DPadRight:
+            case kHIDUsage_GD_DPadLeft:
+            case kHIDUsage_GD_Start:
+            case kHIDUsage_GD_Select:
+            case kHIDUsage_GD_SystemMainMenu: {
+                // TODO: Not implemented
+                break;
+            }
+            default:
+                break;
+            }
+
+            break;
+        }
+        case kHIDPage_Button:
+        case kHIDPage_Consumer: {
+            break;
+        }
+        default:
+            break;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+GamepadIOKit::GamepadIOKit()
+    : hidManager(nullptr)
+{
+    hidManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+    if (hidManager == nullptr) {
+        POMDOG_THROW_EXCEPTION(std::runtime_error, "Error: Failed to call IOHIDManagerCreate");
+    }
+
+    auto deviceMatcher = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (deviceMatcher == nullptr) {
+        POMDOG_THROW_EXCEPTION(std::runtime_error, "Error: Failed to call CFArrayCreateMutable");
+    }
+
+    AppendDeviceMatching(deviceMatcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
+    AppendDeviceMatching(deviceMatcher, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+
+    IOHIDManagerSetDeviceMatchingMultiple(hidManager, deviceMatcher);
+    CFRelease(deviceMatcher);
+
+    IOHIDManagerRegisterDeviceMatchingCallback(
+        hidManager,
+        [](void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+            auto c = reinterpret_cast<GamepadIOKit*>(context);
+            POMDOG_ASSERT(c != nullptr);
+            c->OnDeviceAttached(result, sender, device);
+        },
+        this);
+    IOHIDManagerRegisterDeviceRemovalCallback(
+        hidManager,
+        [](void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+            auto c = reinterpret_cast<GamepadIOKit*>(context);
+            POMDOG_ASSERT(c != nullptr);
+            c->OnDeviceDetached(result, sender, device);
+        },
+        this);
+
+    IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    IOHIDManagerOpen(hidManager, kIOHIDOptionsTypeNone);
+}
+
+GamepadIOKit::~GamepadIOKit()
+{
+    for (auto& device : gamepads) {
+        device.Close();
+    }
+
+    if (hidManager != nullptr) {
+        IOHIDManagerUnscheduleFromRunLoop(hidManager, CFRunLoopGetCurrent(), kCFRunLoopCommonModes);
+        IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
+        CFRelease(hidManager);
+        hidManager = nullptr;
+    }
+}
+
+GamepadCapabilities GamepadIOKit::GetCapabilities(PlayerIndex playerIndex) const
+{
+    const auto index = GamepadHelper::ToInt(playerIndex);
+    POMDOG_ASSERT(index < static_cast<int>(gamepads.size()));
+    return gamepads[index].caps;
+}
+
+GamepadState GamepadIOKit::GetState(PlayerIndex playerIndex) const
+{
+    const auto index = GamepadHelper::ToInt(playerIndex);
+    POMDOG_ASSERT(index < static_cast<int>(gamepads.size()));
+    return gamepads[index].state;
+}
+
+void GamepadIOKit::OnDeviceAttached(IOReturn result, void* sender, IOHIDDeviceRef device)
+{
+    auto gamepad = std::find_if(std::begin(gamepads), std::end(gamepads), [](GamepadDevice& a) {
+        return a.device == nullptr;
+    });
+    if (gamepad == std::end(gamepads)) {
+        return;
+    }
+
+    GamepadHelper::ClearState(gamepad->state);
+    gamepad->device = device;
+    gamepad->state.IsConnected = true;
+
+    auto deviceName = reinterpret_cast<CFStringRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey)));
+    if (deviceName != nullptr) {
+        std::array<char, 256> buffer;
+        std::fill(std::begin(buffer), std::end(buffer), 0);
+        CFStringGetCString(deviceName, buffer.data(), buffer.size(), kCFStringEncodingUTF8);
+        gamepad->caps.Name = buffer.data();
+    }
+    else {
+        gamepad->caps.Name = "unknown";
+    }
+
+    int32_t vendor = 0;
+    int32_t product = 0;
+    int32_t version = 0;
+
+    auto vendorID = reinterpret_cast<CFNumberRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)));
+    if (vendorID != nullptr) {
+        CFNumberGetValue(vendorID, kCFNumberSInt32Type, &vendor);
+    }
+
+    auto productID = reinterpret_cast<CFNumberRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey)));
+    if (productID != nullptr) {
+        CFNumberGetValue(productID, kCFNumberSInt32Type, &product);
+    }
+
+    auto versionNumber = reinterpret_cast<CFNumberRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVersionNumberKey)));
+    if (versionNumber != nullptr) {
+        CFNumberGetValue(versionNumber, kCFNumberSInt32Type, &version);
+    }
+
+    constexpr uint16_t busUSB = 0x03;
+
+    GamepadDeviceID uuid;
+    uuid.BusType = busUSB;
+    uuid.Vendor = static_cast<uint16_t>(vendor);
+    uuid.Product = static_cast<uint16_t>(product);
+    uuid.Version = static_cast<uint16_t>(version);
+
+    std::string controllerName;
+    std::tie(gamepad->mappings, controllerName) = GetMappings(uuid);
+    if (!controllerName.empty()) {
+        gamepad->caps.Name = controllerName;
+    }
+
+    auto elements = IOHIDDeviceCopyMatchingElements(device, nullptr, kIOHIDOptionsTypeNone);
+    if (elements != nullptr) {
+        for (int i = 0; i < CFArrayGetCount(elements); ++i) {
+            auto element = (IOHIDElementRef)(CFArrayGetValueAtIndex(elements, i));
+            if (CFGetTypeID(element) != IOHIDElementGetTypeID()) {
+                continue;
+            }
+
+            const auto usagePage = IOHIDElementGetUsagePage(element);
+            const auto usage = IOHIDElementGetUsage(element);
+
+            switch (IOHIDElementGetType(element)) {
+            case kIOHIDElementTypeInput_Axis:
+            case kIOHIDElementTypeInput_Button:
+            case kIOHIDElementTypeInput_Misc:
+                switch (usagePage) {
+                case kHIDPage_GenericDesktop:
+                    switch (usage) {
+                    case kHIDUsage_GD_X:
+                    case kHIDUsage_GD_Y:
+                    case kHIDUsage_GD_Z:
+                    case kHIDUsage_GD_Rx:
+                    case kHIDUsage_GD_Ry:
+                    case kHIDUsage_GD_Rz: {
+                        const auto thumbStickIndex = static_cast<int>(usage - kHIDUsage_GD_X);
+                        POMDOG_ASSERT(thumbStickIndex >= 0);
+                        POMDOG_ASSERT(thumbStickIndex < static_cast<int>(gamepad->thumbStickInfos.size()));
+
+                        const auto minimum = static_cast<int32_t>(IOHIDElementGetLogicalMin(element));
+                        const auto maximum = static_cast<int32_t>(IOHIDElementGetLogicalMax(element));
+                        gamepad->thumbStickInfos[thumbStickIndex].Minimum = minimum;
+                        gamepad->thumbStickInfos[thumbStickIndex].Range = std::max(1, maximum - minimum);
+                        break;
+                    }
+                    default:
+                        break;
+                    }
+                    break;
+                default:
+                    break;
+                }
+                break;
+            case kIOHIDElementTypeCollection:
+                break;
+            default:
+                break;
+            }
+        }
+
+        CFRelease(elements);
+    }
+
+    Log::Internal("Attached device: " + gamepad->caps.Name);
+
+    IOHIDDeviceOpen(device, kIOHIDOptionsTypeNone);
+    IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetCurrent(), kCFRunLoopCommonModes);
+    IOHIDDeviceRegisterInputValueCallback(
+        device,
+        [](void* context, IOReturn result, void* sender, IOHIDValueRef value) {
+            auto c = reinterpret_cast<GamepadDevice*>(context);
+            POMDOG_ASSERT(c != nullptr);
+            c->OnDeviceInput(result, sender, value);
+        },
+        &(*gamepad));
+}
+
+void GamepadIOKit::OnDeviceDetached(IOReturn result, void* sender, IOHIDDeviceRef device)
+{
+    auto gamepad = std::find_if(std::begin(gamepads), std::end(gamepads), [&](GamepadDevice& a) {
+        return a.device == device;
+    });
+    if (gamepad == std::end(gamepads)) {
+        Log::Internal("The device was not found");
+        return;
+    }
+
+    Log::Internal("Detached device: " + gamepad->caps.Name);
+    gamepad->Close();
+}
+
+} // namespace Apple
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem.IOKit/GamepadIOKit.hpp
+++ b/src/InputSystem.IOKit/GamepadIOKit.hpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include "../InputSystem/GamepadMappings.hpp"
+#include "Pomdog/Input/Gamepad.hpp"
+#include "Pomdog/Input/GamepadCapabilities.hpp"
+#include "Pomdog/Input/GamepadState.hpp"
+#include <IOKit/hid/IOHIDManager.h>
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace Apple {
+
+struct ThumbStickInfo final {
+    int32_t Minimum = 0;
+    int32_t Range = 0;
+};
+
+class GamepadDevice final {
+public:
+    GamepadCapabilities caps;
+    GamepadState state;
+    IOHIDDeviceRef device = nullptr;
+    GamepadMappings mappings;
+    std::array<ThumbStickInfo, 6> thumbStickInfos;
+
+public:
+    bool Open();
+
+    void Close();
+
+    void OnDeviceInput(IOReturn result, void* sender, IOHIDValueRef value);
+};
+
+class GamepadIOKit final : public Gamepad {
+public:
+    GamepadIOKit();
+
+    ~GamepadIOKit();
+
+    GamepadCapabilities GetCapabilities(PlayerIndex index) const override;
+
+    GamepadState GetState(PlayerIndex index) const override;
+
+private:
+    std::array<GamepadDevice, 4> gamepads;
+    IOHIDManagerRef hidManager;
+
+    void OnDeviceAttached(IOReturn result, void* sender, IOHIDDeviceRef device);
+    void OnDeviceDetached(IOReturn result, void* sender, IOHIDDeviceRef device);
+};
+
+} // namespace Apple
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem.Linux/GamepadLinux.cpp
+++ b/src/InputSystem.Linux/GamepadLinux.cpp
@@ -1,0 +1,359 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#include "GamepadLinux.hpp"
+#include "../InputSystem/GamepadHelper.hpp"
+#include "Pomdog/Logging/Log.hpp"
+#include "Pomdog/Utility/Assert.hpp"
+#include <linux/input.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <algorithm>
+#include <tuple>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace Linux {
+namespace {
+
+constexpr size_t BitCount(size_t n)
+{
+    return (n / 8) + 1;
+}
+
+template <typename T>
+bool HasBit(const T& array, uint32_t bit)
+{
+    return ((1 << (bit % 8)) & array[bit / 8]) != 0;
+}
+
+ButtonState GetTriggerButtonValue(int value)
+{
+    return (value > 0) ? ButtonState::Pressed : ButtonState::Released;
+}
+
+float GetThumbStickValue(int value, const ThumbStickInfo& info)
+{
+    return (static_cast<float>((value - info.Minimum) * 2 - info.Range) / info.Range);
+}
+
+} // unnamed namespace
+
+bool GamepadDevice::Open(int deviceIndex)
+{
+    POMDOG_ASSERT(fd == -1);
+
+    const auto js = "/dev/input/event" + std::to_string(deviceIndex);
+    fd = ::open(js.c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd < 0) {
+        fd = -1;
+        return false;
+    }
+
+    POMDOG_ASSERT(fd >= 0);
+
+    struct input_id inputId;
+    if (::ioctl(fd, EVIOCGID, &inputId) < 0) {
+        Close();
+        return false;
+    }
+
+    GamepadDeviceID uuid;
+    uuid.BusType = static_cast<uint16_t>(inputId.bustype);
+    uuid.Vendor = static_cast<uint16_t>(inputId.vendor);
+    uuid.Product = static_cast<uint16_t>(inputId.product);
+    uuid.Version = static_cast<uint16_t>(inputId.version);
+
+    // TODO: Use udev-joystick-blacklist here
+    // https://github.com/denilsonsa/udev-joystick-blacklist
+
+    std::array<uint8_t, BitCount(EV_MAX)> evBits;
+    std::array<uint8_t, BitCount(KEY_MAX)> keyBits;
+    std::array<uint8_t, BitCount(ABS_MAX)> absBits;
+
+    std::fill(std::begin(evBits), std::end(evBits), 0);
+    std::fill(std::begin(keyBits), std::end(keyBits), 0);
+    std::fill(std::begin(absBits), std::end(absBits), 0);
+
+    if ((ioctl(fd, EVIOCGBIT(0, evBits.size()), evBits.data()) < 0) ||
+        (ioctl(fd, EVIOCGBIT(EV_KEY, keyBits.size()), keyBits.data()) < 0) ||
+        (ioctl(fd, EVIOCGBIT(EV_ABS, absBits.size()), absBits.data()) < 0)) {
+        Close();
+        return false;
+    }
+
+    if (!HasBit(evBits, EV_KEY) ||
+        !HasBit(evBits, EV_ABS) ||
+        !HasBit(absBits, ABS_X) ||
+        !HasBit(absBits, ABS_Y)) {
+        // The device is not a joystick or gamepad.
+        Close();
+        return false;
+    }
+
+    int numOfButtons = 0;
+    std::fill(std::begin(keyMap), std::end(keyMap), -1);
+
+    for (int i = BTN_JOYSTICK; i < KEY_MAX; ++i) {
+        if (HasBit(keyBits, static_cast<uint32_t>(i))) {
+            const auto index = i - BTN_GAMEPAD;
+            if ((index < 0) || (index >= static_cast<int>(keyMap.size()))) {
+                continue;
+            }
+            keyMap[index] = static_cast<int8_t>(numOfButtons);
+            ++numOfButtons;
+        }
+    }
+
+    int numOfAxis = 0;
+    for (int i = ABS_X; i <= ABS_RZ; ++i) {
+        if (HasBit(absBits, i)) {
+            struct input_absinfo absInfo;
+            if (::ioctl(fd, EVIOCGABS(i), &absInfo) < 0) {
+                continue;
+            }
+
+            POMDOG_ASSERT(i >= 0);
+            POMDOG_ASSERT(i < static_cast<int>(thumbStickInfos.size()));
+            thumbStickInfos[i].Minimum = absInfo.minimum;
+            thumbStickInfos[i].Range = std::max(1, absInfo.maximum - absInfo.minimum);
+            ++numOfAxis;
+        }
+    }
+
+    std::array<char, 256> gamepadName;
+    std::fill(std::begin(gamepadName), std::end(gamepadName), 0);
+    if (::ioctl(fd, EVIOCGNAME(255), gamepadName.data()) < 0) {
+        Close();
+        return false;
+    }
+
+    caps.Name = gamepadName.data();
+    caps.ThumbStickCount = std::max(0, numOfAxis);
+    caps.ButtonCount = std::max(0, numOfButtons);
+
+    std::string controllerName;
+    std::tie(this->mappings, controllerName) = GetMappings(uuid);
+    if (!controllerName.empty()) {
+        this->caps.Name = controllerName;
+    }
+
+    GamepadHelper::ClearState(state);
+    state.IsConnected = true;
+
+    this->deviceEventIndex = deviceIndex;
+
+    Log::Internal("Open gamepad: " + caps.Name + " at " + js);
+    return true;
+}
+
+void GamepadDevice::Close()
+{
+    if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+    }
+
+    GamepadHelper::ClearState(state);
+    state.IsConnected = false;
+
+    caps.Name = "";
+    caps.ThumbStickCount = 0;
+    caps.ButtonCount = 0;
+}
+
+bool GamepadDevice::HasFileDescriptor() const
+{
+    return fd >= 0;
+}
+
+void GamepadDevice::PollEvents()
+{
+    for (;;) {
+        struct input_event event;
+
+        errno = 0;
+        if (::read(fd, &event, sizeof(event)) < 0) {
+            if (errno == ENODEV) {
+                Log::Internal("Disconnect gamepad: " + caps.Name);
+                Close();
+            }
+            break;
+        }
+
+        switch (event.type) {
+        case EV_KEY: {
+            const auto physicalIndex = static_cast<int>(event.code) - BTN_GAMEPAD;
+            if (physicalIndex >= static_cast<int>(keyMap.size())) {
+                break;
+            }
+            const auto buttonIndex = keyMap[physicalIndex];
+            if (auto button = GetButton(state, mappings.buttons, buttonIndex); button != nullptr) {
+                (*button) = (event.value != 0) ? ButtonState::Pressed: ButtonState::Released;
+            }
+            break;
+        }
+        case EV_ABS:
+            switch (event.code) {
+            case ABS_HAT0X:
+            case ABS_HAT0Y:
+            case ABS_HAT1X:
+            case ABS_HAT1Y:
+            case ABS_HAT2X:
+            case ABS_HAT2Y:
+            case ABS_HAT3X:
+            case ABS_HAT3Y: {
+                const auto code = (event.code - ABS_HAT0X);
+                const auto axis = code % 2;
+                if (event.value == 0) {
+                    if (axis == 0) {
+                        state.DPad.Left = ButtonState::Released;
+                        state.DPad.Right = ButtonState::Released;
+                    }
+                    else {
+                        state.DPad.Up = ButtonState::Released;
+                        state.DPad.Down = ButtonState::Released;
+                    }
+                }
+                else if (event.value > 0) {
+                    if (axis == 0) {
+                        state.DPad.Right = ButtonState::Pressed;
+                    }
+                    else {
+                        state.DPad.Down = ButtonState::Pressed;
+                    }
+                }
+                else if (event.value < 0) {
+                    if (axis == 0) {
+                        state.DPad.Left = ButtonState::Pressed;
+                    }
+                    else {
+                        state.DPad.Up = ButtonState::Pressed;
+                    }
+                }
+                break;
+            }
+            case ABS_X:
+            case ABS_Y:
+            case ABS_Z:
+            case ABS_RX:
+            case ABS_RY:
+            case ABS_RZ:
+                static_assert(ABS_X == 0, "");
+                static_assert(ABS_Y == 1, "");
+                static_assert(ABS_Z == 2, "");
+                static_assert(ABS_RX == 3, "");
+                static_assert(ABS_RY == 4, "");
+                static_assert(ABS_RZ == 5, "");
+                POMDOG_ASSERT(event.code >= 0);
+                POMDOG_ASSERT(event.code < static_cast<int>(mappings.axes.size()));
+                POMDOG_ASSERT(event.code < static_cast<int>(thumbStickInfos.size()));
+
+                switch (mappings.axes[event.code]) {
+                case AxesKind::LeftTrigger:
+                    state.Buttons.LeftTrigger = GetTriggerButtonValue(event.value);
+                    break;
+                case AxesKind::RightTrigger:
+                    state.Buttons.RightTrigger = GetTriggerButtonValue(event.value);
+                    break;
+                case AxesKind::LeftStickX:
+                    state.ThumbSticks.Left.X = GetThumbStickValue(event.value, thumbStickInfos[event.code]);
+                    break;
+                case AxesKind::LeftStickY:
+                    state.ThumbSticks.Left.Y = GetThumbStickValue(event.value, thumbStickInfos[event.code]);
+                    break;
+                case AxesKind::RightStickX:
+                    state.ThumbSticks.Right.X = GetThumbStickValue(event.value, thumbStickInfos[event.code]);
+                    break;
+                case AxesKind::RightStickY:
+                    state.ThumbSticks.Right.Y = GetThumbStickValue(event.value, thumbStickInfos[event.code]);
+                    break;
+                default:
+                    break;
+                }
+                break;
+            default:
+                break;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+GamepadLinux::GamepadLinux()
+{
+}
+
+GamepadLinux::~GamepadLinux()
+{
+    for (auto& gamepad : gamepads) {
+        if (gamepad.HasFileDescriptor()) {
+            Log::Internal("Close gamepad: " + gamepad.caps.Name);
+            gamepad.Close();
+        }
+    }
+}
+
+GamepadCapabilities GamepadLinux::GetCapabilities(PlayerIndex playerIndex) const
+{
+    const auto index = GamepadHelper::ToInt(playerIndex);
+    POMDOG_ASSERT(index < static_cast<int>(gamepads.size()));
+    return gamepads[index].caps;
+}
+
+GamepadState GamepadLinux::GetState(PlayerIndex playerIndex) const
+{
+    const auto index = GamepadHelper::ToInt(playerIndex);
+    POMDOG_ASSERT(index < static_cast<int>(gamepads.size()));
+    return gamepads[index].state;
+}
+
+void GamepadLinux::EnumerateDevices()
+{
+    auto gamepad = std::begin(gamepads);
+
+    for (int i = 0; i < 32; i++) {
+        while ((gamepad != std::end(gamepads)) && gamepad->HasFileDescriptor()) {
+            ++gamepad;
+        }
+        if (gamepad == std::end(gamepads)) {
+            break;
+        }
+
+        auto iter = std::find_if(std::begin(gamepads), std::end(gamepads), [&](auto& dev) {
+            return (dev.HasFileDescriptor() && (dev.deviceEventIndex == i));
+        });
+        if (iter != std::end(gamepads)) {
+            // The device is already opened.
+            continue;
+        }
+
+        POMDOG_ASSERT(!gamepad->HasFileDescriptor());
+
+        if (!gamepad->Open(i)) {
+            gamepad->Close();
+            continue;
+        }
+    }
+}
+
+void GamepadLinux::PollEvents()
+{
+    EnumerateDevices();
+
+    for (auto& gamepad : gamepads) {
+        if (!gamepad.HasFileDescriptor()) {
+            continue;
+        }
+
+        gamepad.PollEvents();
+    }
+}
+
+} // namespace Linux
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem.Linux/GamepadLinux.hpp
+++ b/src/InputSystem.Linux/GamepadLinux.hpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include "../InputSystem/GamepadMappings.hpp"
+#include "../InputSystem/NativeGamepad.hpp"
+#include "Pomdog/Input/Gamepad.hpp"
+#include "Pomdog/Input/GamepadCapabilities.hpp"
+#include "Pomdog/Input/GamepadState.hpp"
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace Linux {
+
+struct ThumbStickInfo final {
+    int32_t Minimum = 0;
+    int32_t Range = 0;
+};
+
+class GamepadDevice final {
+public:
+    int fd = -1;
+    int deviceEventIndex = 0;
+    GamepadCapabilities caps;
+    GamepadState state;
+    GamepadMappings mappings;
+    std::array<int8_t, 16> keyMap;
+    std::array<ThumbStickInfo, 6> thumbStickInfos;
+
+public:
+    bool Open(int deviceIndex);
+
+    void Close();
+
+    bool HasFileDescriptor() const;
+
+    void PollEvents();
+};
+
+class GamepadLinux final : public NativeGamepad {
+public:
+    GamepadLinux();
+
+    ~GamepadLinux();
+
+    GamepadCapabilities GetCapabilities(PlayerIndex index) const override;
+
+    GamepadState GetState(PlayerIndex index) const override;
+
+    void EnumerateDevices();
+
+    void PollEvents() override;
+
+private:
+    std::array<GamepadDevice, 4> gamepads;
+};
+
+} // namespace Linux
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadFactory.cpp
+++ b/src/InputSystem/GamepadFactory.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#include "GamepadFactory.hpp"
+#include "Pomdog/Basic/Platform.hpp"
+#ifdef POMDOG_PLATFORM_LINUX
+#include "../InputSystem.Linux/GamepadLinux.hpp"
+#else
+#include "../InputSystem/NativeGamepad.hpp"
+#endif
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+
+std::unique_ptr<NativeGamepad> CreateGamepad()
+{
+#ifdef POMDOG_PLATFORM_LINUX
+    return std::make_unique<Linux::GamepadLinux>();
+#else
+    return nullptr;
+#endif
+}
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadFactory.hpp
+++ b/src/InputSystem/GamepadFactory.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include <memory>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+
+class NativeGamepad;
+
+std::unique_ptr<NativeGamepad> CreateGamepad();
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadHelper.cpp
+++ b/src/InputSystem/GamepadHelper.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#include "GamepadHelper.hpp"
+#include "Pomdog/Input/GamepadState.hpp"
+#include "Pomdog/Utility/Assert.hpp"
+#include "Pomdog/Utility/StringHelper.hpp"
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace {
+
+template <typename T>
+T SwapEndian(T u)
+{
+    static_assert(sizeof(uint8_t) == 1, "");
+    union {
+        T u;
+        uint8_t u8[sizeof(T)];
+    } source, dest;
+    source.u = u;
+    for (size_t k = 0; k < sizeof(T); k++) {
+        dest.u8[k] = source.u8[sizeof(T) - k - 1];
+    }
+    return dest.u;
+}
+
+} // namespace
+
+std::string GamepadHelper::ToString(const GamepadDeviceID& device)
+{
+    std::array<uint16_t, 8> uuid;
+    std::fill(std::begin(uuid), std::end(uuid), static_cast<uint16_t>(0));
+    if ((device.Vendor != 0) && (device.Product != 0)) {
+        uuid[0] = device.BusType;
+        uuid[1] = 0;
+        uuid[2] = device.Vendor;
+        uuid[3] = 0;
+        uuid[4] = device.Product;
+        uuid[5] = 0;
+        uuid[6] = device.Version;
+        uuid[7] = 0;
+    }
+
+    std::string s;
+    for (auto u : uuid) {
+        s += StringHelper::Format("%04x", SwapEndian(u));
+    }
+    return s;
+}
+
+int GamepadHelper::ToInt(PlayerIndex index)
+{
+    POMDOG_ASSERT(static_cast<int>(index) >= 1);
+    return static_cast<int>(index) - 1;
+}
+
+void GamepadHelper::ClearState(GamepadState& state)
+{
+    state.Buttons.A = ButtonState::Released;
+    state.Buttons.B = ButtonState::Released;
+    state.Buttons.X = ButtonState::Released;
+    state.Buttons.Y = ButtonState::Released;
+    state.Buttons.LeftShoulder = ButtonState::Released;
+    state.Buttons.RightShoulder = ButtonState::Released;
+    state.Buttons.LeftTrigger = ButtonState::Released;
+    state.Buttons.RightTrigger = ButtonState::Released;
+    state.Buttons.LeftMenu = ButtonState::Released;
+    state.Buttons.RightMenu = ButtonState::Released;
+    state.Buttons.LeftStick = ButtonState::Released;
+    state.Buttons.RightStick = ButtonState::Released;
+    state.Buttons.Guide = ButtonState::Released;
+    state.Buttons.Extra1 = ButtonState::Released;
+    state.Buttons.Extra2 = ButtonState::Released;
+    state.DPad.Down = ButtonState::Released;
+    state.DPad.Up = ButtonState::Released;
+    state.DPad.Left = ButtonState::Released;
+    state.DPad.Right = ButtonState::Released;
+    state.ThumbSticks.Left = Vector2::Zero;
+    state.ThumbSticks.Right = Vector2::Zero;
+    state.IsConnected = false;
+}
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadHelper.hpp
+++ b/src/InputSystem/GamepadHelper.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include "Pomdog/Input/PlayerIndex.hpp"
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace Pomdog {
+
+struct GamepadState;
+
+namespace Detail {
+namespace InputSystem {
+
+struct GamepadDeviceID final {
+    uint16_t BusType = 0;
+    uint16_t Vendor = 0;
+    uint16_t Product = 0;
+    uint16_t Version = 0;
+};
+
+namespace GamepadHelper {
+
+std::string ToString(const GamepadDeviceID& uuid);
+
+int ToInt(PlayerIndex index);
+
+void ClearState(GamepadState& state);
+
+} // namespace GamepadHelper
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadMappings.cpp
+++ b/src/InputSystem/GamepadMappings.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#include "GamepadMappings.hpp"
+#include "../Basic/ConditionalCompilation.hpp"
+#include "Pomdog/Basic/Platform.hpp"
+#include "Pomdog/Input/GamepadState.hpp"
+#include "Pomdog/Logging/Log.hpp"
+#include "Pomdog/Utility/Assert.hpp"
+#include "Pomdog/Utility/StringHelper.hpp"
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+namespace {
+
+#ifdef POMDOG_PLATFORM_MACOSX
+#ifndef __MACOSX__
+#define __MACOSX__ 1
+#endif
+#endif
+
+#ifdef POMDOG_PLATFORM_LINUX
+#ifndef __LINUX__
+#define __LINUX__ 1
+#endif
+#endif
+#include "SDL_gamecontrollerdb.h"
+
+std::tuple<std::string, const char*> Parse(const char* source, char delimiter)
+{
+    std::string identifier;
+    while (*source != 0) {
+        if (*source == delimiter) {
+            ++source;
+            break;
+        }
+        identifier += *source;
+        ++source;
+    }
+    return std::make_tuple(identifier, source);
+}
+
+void ParseMapping(const char* source, GamepadMappings& mappings, std::string& name)
+{
+    std::string uuid;
+    std::string key;
+    std::string index;
+
+    std::tie(uuid, source) = Parse(source, ',');
+    std::tie(name, source) = Parse(source, ',');
+
+    const std::array<ButtonKind, 21> buttons = {{
+        ButtonKind::A,
+        ButtonKind::B,
+        ButtonKind::LeftMenu,
+        ButtonKind::None, // dpdown
+        ButtonKind::None, // dpleft
+        ButtonKind::None, // dpright
+        ButtonKind::None, // dpup
+        ButtonKind::Guide,
+        ButtonKind::LeftShoulder,
+        ButtonKind::LeftStick,
+        ButtonKind::LeftTrigger,
+        ButtonKind::None, // leftx
+        ButtonKind::None, // lefty
+        ButtonKind::RightShoulder,
+        ButtonKind::RightStick,
+        ButtonKind::RightTrigger,
+        ButtonKind::None, // rightx
+        ButtonKind::None, // righty
+        ButtonKind::RightMenu,
+        ButtonKind::X,
+        ButtonKind::Y,
+    }};
+
+    const std::array<AxesKind, 21> axes = {{
+        AxesKind::None, // A
+        AxesKind::None, // B
+        AxesKind::None, // LeftMenu
+        AxesKind::None, // dpdown
+        AxesKind::None, // dpleft
+        AxesKind::None, // dpright
+        AxesKind::None, // dpup
+        AxesKind::None, // Guide
+        AxesKind::None, // LeftShoulder
+        AxesKind::None, // LeftStick
+        AxesKind::LeftTrigger,
+        AxesKind::LeftStickX,
+        AxesKind::LeftStickY,
+        AxesKind::None, // RightShoulder
+        AxesKind::None, // RightStick
+        AxesKind::RightTrigger,
+        AxesKind::RightStickX,
+        AxesKind::RightStickY,
+        AxesKind::None, // RightMenu
+        AxesKind::None, // X
+        AxesKind::None, // Y
+    }};
+
+    int buttonIndex = 0;
+    while (*source != 0) {
+        std::tie(key, source) = Parse(source, ':');
+        std::tie(index, source) = Parse(source, ',');
+
+        Log::Internal(key + " " + index);
+
+        if (index[0] == 'b') {
+            int i = std::atoi(StringHelper::TrimLeft(index, 'b').c_str());
+            if ((i >= 0) && (i < static_cast<int>(mappings.buttons.size()))) {
+                mappings.buttons[i] = buttons[buttonIndex];
+            }
+        }
+        else if (index[0] == 'a') {
+            auto s = StringHelper::TrimRight(index, '~');
+            s = StringHelper::TrimLeft(s, '+');
+            s = StringHelper::TrimLeft(s, '-');
+            s = StringHelper::TrimLeft(s, 'a');
+            int i = std::atoi(s.c_str());
+            if ((i >= 0) && (i < static_cast<int>(mappings.axes.size())))  {
+                mappings.axes[i] = axes[buttonIndex];
+            }
+        }
+        ++buttonIndex;
+    }
+}
+
+ButtonKind ToButtonIndex(int physicalIndex, GamepadButtonMappings mappings)
+{
+    if ((physicalIndex < 0) || (physicalIndex >= static_cast<int>(mappings.size()))) {
+        return ButtonKind::None;
+    }
+    POMDOG_ASSERT(physicalIndex >= 0);
+    POMDOG_ASSERT(physicalIndex < static_cast<int>(mappings.size()));
+    return mappings[physicalIndex];
+}
+
+} // namespace
+
+ButtonState* GetButton(GamepadState& state, const GamepadButtonMappings& mappings, int physicalIndex)
+{
+    const auto buttonKind = ToButtonIndex(physicalIndex, mappings);
+    if (buttonKind == ButtonKind::None) {
+        return nullptr;
+    }
+    const auto index = static_cast<int>(buttonKind);
+
+    std::array<ButtonState*, 15> buttons = {{
+        &state.Buttons.A,
+        &state.Buttons.B,
+        &state.Buttons.X,
+        &state.Buttons.Y,
+        &state.Buttons.LeftShoulder,
+        &state.Buttons.RightShoulder,
+        &state.Buttons.LeftTrigger,
+        &state.Buttons.RightTrigger,
+        &state.Buttons.LeftMenu,
+        &state.Buttons.RightMenu,
+        &state.Buttons.LeftStick,
+        &state.Buttons.RightStick,
+        &state.Buttons.Guide,
+        &state.Buttons.Extra1,
+        &state.Buttons.Extra2,
+    }};
+    POMDOG_ASSERT(index >= 0);
+    POMDOG_ASSERT(index < static_cast<int>(buttons.size()));
+    return buttons[index];
+}
+
+std::tuple<GamepadMappings, std::string> GetMappings(const GamepadDeviceID& uuid)
+{
+    auto uuidString = GamepadHelper::ToString(uuid);
+
+    Log::Internal("UUID: " + uuidString);
+
+    GamepadMappings mappings;
+#ifdef POMDOG_PLATFORM_LINUX
+    // NOTE: Please see this header
+    // https://github.com/torvalds/linux/blob/4982327ff6755377a8a66e84113f496f3a6c53bc/include/uapi/linux/input-event-codes.h#L379-L398
+    mappings.buttons = {{
+        ButtonKind::A,
+        ButtonKind::B,
+        ButtonKind::X,
+        ButtonKind::Y,
+        ButtonKind::LeftShoulder,
+        ButtonKind::RightShoulder,
+        ButtonKind::LeftMenu,
+        ButtonKind::RightMenu,
+        ButtonKind::Guide,
+        ButtonKind::LeftStick,
+        ButtonKind::RightStick,
+        ButtonKind::Extra1,
+        ButtonKind::Extra2,
+        ButtonKind::None,
+        ButtonKind::None,
+        ButtonKind::None,
+    }};
+#else
+    // POMDOG_PLATFORM_MACOSX
+    mappings.buttons = {{
+        ButtonKind::A,
+        ButtonKind::B,
+        ButtonKind::X,
+        ButtonKind::Y,
+        ButtonKind::LeftShoulder,
+        ButtonKind::RightShoulder,
+        ButtonKind::LeftTrigger,
+        ButtonKind::RightTrigger,
+        ButtonKind::LeftMenu,
+        ButtonKind::RightMenu,
+        ButtonKind::LeftStick,
+        ButtonKind::RightStick,
+        ButtonKind::Guide,
+        ButtonKind::Extra1,
+        ButtonKind::Extra2,
+        ButtonKind::None,
+    }};
+#endif
+
+    mappings.axes = {{
+        AxesKind::LeftStickX,
+        AxesKind::LeftStickY,
+        AxesKind::LeftTrigger,
+        AxesKind::RightStickX,
+        AxesKind::RightStickY,
+        AxesKind::RightTrigger,
+    }};
+
+    std::string deviceName;
+    for (auto m : s_ControllerMappings) {
+        if (m == nullptr) {
+            break;
+        }
+        std::string s = m;
+        if (StringHelper::HasPrefix(s, uuidString)) {
+            // found
+            std::fill(std::begin(mappings.buttons), std::end(mappings.buttons), ButtonKind::None);
+            std::fill(std::begin(mappings.axes), std::end(mappings.axes), AxesKind::None);
+            ParseMapping(m, mappings, deviceName);
+            break;
+        }
+    }
+    return std::make_tuple(mappings, deviceName);
+}
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/GamepadMappings.hpp
+++ b/src/InputSystem/GamepadMappings.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include "GamepadHelper.hpp"
+#include "Pomdog/Input/GamepadCapabilities.hpp"
+#include "Pomdog/Input/GamepadState.hpp"
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+
+enum class AxesKind : std::int8_t {
+    None = -1,
+    LeftStickX = 0,
+    LeftStickY = 1,
+    RightStickX = 2,
+    RightStickY = 3,
+    LeftTrigger = 4,
+    RightTrigger = 5,
+};
+
+enum class ButtonKind : std::int8_t {
+    None = -1,
+    A = 0,
+    B = 1,
+    X = 2,
+    Y = 3,
+    LeftShoulder = 4,
+    RightShoulder = 5,
+    LeftTrigger = 6,
+    RightTrigger = 7,
+    LeftMenu = 8,
+    RightMenu = 9,
+    LeftStick = 10,
+    RightStick = 11,
+    Guide = 12,
+    Extra1 = 13,
+    Extra2 = 14,
+};
+
+using GamepadButtonMappings = std::array<ButtonKind, 16>;
+
+struct GamepadMappings {
+    GamepadButtonMappings buttons;
+    std::array<AxesKind, 6> axes;
+};
+
+ButtonState* GetButton(GamepadState& state, const GamepadButtonMappings& mappings, int index);
+
+std::tuple<GamepadMappings, std::string> GetMappings(const GamepadDeviceID& uuid);
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/InputSystem/NativeGamepad.hpp
+++ b/src/InputSystem/NativeGamepad.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2013-2018 mogemimi. Distributed under the MIT license.
+
+#pragma once
+
+#include "Pomdog/Input/Gamepad.hpp"
+
+namespace Pomdog {
+namespace Detail {
+namespace InputSystem {
+
+class NativeGamepad : public Gamepad {
+public:
+    virtual ~NativeGamepad() = default;
+
+    virtual void PollEvents() = 0;
+};
+
+} // namespace InputSystem
+} // namespace Detail
+} // namespace Pomdog

--- a/src/Platform.Cocoa/GameHostCocoa.hpp
+++ b/src/Platform.Cocoa/GameHostCocoa.hpp
@@ -50,6 +50,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse() override;
 
+    std::shared_ptr<Gamepad> GetGamepad() override;
+
     SurfaceFormat GetBackBufferSurfaceFormat() const override;
 
     DepthFormat GetBackBufferDepthStencilFormat() const override;

--- a/src/Platform.Cocoa/GameHostCocoa.mm
+++ b/src/Platform.Cocoa/GameHostCocoa.mm
@@ -5,6 +5,7 @@
 #include "OpenGLContextCocoa.hpp"
 #include "KeyboardCocoa.hpp"
 #include "MouseCocoa.hpp"
+#include "../InputSystem.IOKit/GamepadIOKit.hpp"
 #include "../RenderSystem/GraphicsCommandQueueImmediate.hpp"
 #include "../RenderSystem.GL4/GraphicsContextGL4.hpp"
 #include "../RenderSystem.GL4/GraphicsDeviceGL4.hpp"
@@ -32,6 +33,7 @@
 
 using Pomdog::Detail::GL4::GraphicsDeviceGL4;
 using Pomdog::Detail::GL4::GraphicsContextGL4;
+using Pomdog::Detail::InputSystem::Apple::GamepadIOKit;
 
 namespace Pomdog {
 namespace Detail {
@@ -79,6 +81,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse();
 
+    std::shared_ptr<Gamepad> GetGamepad();
+
     SurfaceFormat GetBackBufferSurfaceFormat() const noexcept;
 
     DepthFormat GetBackBufferDepthStencilFormat() const noexcept;
@@ -123,6 +127,7 @@ private:
     std::unique_ptr<Pomdog::AssetManager> assetManager;
     std::shared_ptr<KeyboardCocoa> keyboard;
     std::shared_ptr<MouseCocoa> mouse;
+    std::shared_ptr<GamepadIOKit> gamepad;
 
     __weak PomdogOpenGLView* openGLView;
     Duration presentationInterval;
@@ -174,6 +179,7 @@ GameHostCocoa::Impl::Impl(
     audioEngine = std::make_shared<Pomdog::AudioEngine>();
     keyboard = std::make_shared<KeyboardCocoa>();
     mouse = std::make_shared<MouseCocoa>();
+    gamepad = std::make_shared<GamepadIOKit>();
 
     // Connect to system event signal
     POMDOG_ASSERT(eventQueue);
@@ -205,6 +211,7 @@ GameHostCocoa::Impl::~Impl()
 
     systemEventConnection.Disconnect();
     assetManager.reset();
+    gamepad.reset();
     keyboard.reset();
     mouse.reset();
     audioEngine.reset();
@@ -463,6 +470,11 @@ std::shared_ptr<Mouse> GameHostCocoa::Impl::GetMouse()
     return mouse;
 }
 
+std::shared_ptr<Gamepad> GameHostCocoa::Impl::GetGamepad()
+{
+    return gamepad;
+}
+
 SurfaceFormat GameHostCocoa::Impl::GetBackBufferSurfaceFormat() const noexcept
 {
     return backBufferSurfaceFormat;
@@ -545,6 +557,12 @@ std::shared_ptr<Mouse> GameHostCocoa::GetMouse()
 {
     POMDOG_ASSERT(impl);
     return impl->GetMouse();
+}
+
+std::shared_ptr<Gamepad> GameHostCocoa::GetGamepad()
+{
+    POMDOG_ASSERT(impl);
+    return impl->GetGamepad();
 }
 
 SurfaceFormat GameHostCocoa::GetBackBufferSurfaceFormat() const

--- a/src/Platform.Cocoa/GameHostMetal.hpp
+++ b/src/Platform.Cocoa/GameHostMetal.hpp
@@ -54,6 +54,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse() override;
 
+    std::shared_ptr<Gamepad> GetGamepad() override;
+
     SurfaceFormat GetBackBufferSurfaceFormat() const override;
 
     DepthFormat GetBackBufferDepthStencilFormat() const override;

--- a/src/Platform.Cocoa/GameHostMetal.mm
+++ b/src/Platform.Cocoa/GameHostMetal.mm
@@ -4,6 +4,7 @@
 #include "GameWindowCocoa.hpp"
 #include "KeyboardCocoa.hpp"
 #include "MouseCocoa.hpp"
+#include "../InputSystem.IOKit/GamepadIOKit.hpp"
 #include "../RenderSystem/GraphicsCommandQueueImmediate.hpp"
 #include "../RenderSystem.Metal/GraphicsContextMetal.hpp"
 #include "../RenderSystem.Metal/GraphicsDeviceMetal.hpp"
@@ -35,6 +36,7 @@
 
 using Pomdog::Detail::Metal::GraphicsContextMetal;
 using Pomdog::Detail::Metal::GraphicsDeviceMetal;
+using Pomdog::Detail::InputSystem::Apple::GamepadIOKit;
 
 namespace Pomdog {
 namespace Detail {
@@ -114,6 +116,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse();
 
+    std::shared_ptr<Gamepad> GetGamepad();
+
     SurfaceFormat GetBackBufferSurfaceFormat() const noexcept;
 
     DepthFormat GetBackBufferDepthStencilFormat() const noexcept;
@@ -145,6 +149,7 @@ private:
     std::unique_ptr<Pomdog::AssetManager> assetManager;
     std::shared_ptr<KeyboardCocoa> keyboard;
     std::shared_ptr<MouseCocoa> mouse;
+    std::shared_ptr<GamepadIOKit> gamepad;
 
     __weak MTKView* metalView;
     Duration presentationInterval;
@@ -206,6 +211,7 @@ GameHostMetal::Impl::Impl(
     audioEngine = std::make_shared<AudioEngine>();
     keyboard = std::make_shared<KeyboardCocoa>();
     mouse = std::make_shared<MouseCocoa>();
+    gamepad = std::make_shared<GamepadIOKit>();
 
     // Connect to system event signal
     POMDOG_ASSERT(eventQueue);
@@ -225,6 +231,7 @@ GameHostMetal::Impl::~Impl()
 {
     systemEventConnection.Disconnect();
     assetManager.reset();
+    gamepad.reset();
     keyboard.reset();
     mouse.reset();
     audioEngine.reset();
@@ -428,6 +435,11 @@ std::shared_ptr<Mouse> GameHostMetal::Impl::GetMouse()
     return mouse;
 }
 
+std::shared_ptr<Gamepad> GameHostMetal::Impl::GetGamepad()
+{
+    return gamepad;
+}
+
 SurfaceFormat GameHostMetal::Impl::GetBackBufferSurfaceFormat() const noexcept
 {
     return backBufferSurfaceFormat;
@@ -522,6 +534,12 @@ std::shared_ptr<Mouse> GameHostMetal::GetMouse()
 {
     POMDOG_ASSERT(impl);
     return impl->GetMouse();
+}
+
+std::shared_ptr<Gamepad> GameHostMetal::GetGamepad()
+{
+    POMDOG_ASSERT(impl);
+    return impl->GetGamepad();
 }
 
 SurfaceFormat GameHostMetal::GetBackBufferSurfaceFormat() const

--- a/src/Platform.Win32/GameHostWin32.cpp
+++ b/src/Platform.Win32/GameHostWin32.cpp
@@ -527,6 +527,14 @@ std::shared_ptr<Mouse> GameHostWin32::GetMouse()
     return impl->GetMouse();
 }
 
+std::shared_ptr<Gamepad> GameHostWin32::GetGamepad()
+{
+    POMDOG_ASSERT(impl);
+    // FIXME: Add DirectInput support
+    // https://github.com/mogemimi/pomdog/pull/16
+    return nullptr;
+}
+
 SurfaceFormat GameHostWin32::GetBackBufferSurfaceFormat() const
 {
     POMDOG_ASSERT(impl);

--- a/src/Platform.Win32/GameHostWin32.hpp
+++ b/src/Platform.Win32/GameHostWin32.hpp
@@ -52,6 +52,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse() override;
 
+    std::shared_ptr<Gamepad> GetGamepad() override;
+
     SurfaceFormat GetBackBufferSurfaceFormat() const override;
 
     DepthFormat GetBackBufferDepthStencilFormat() const override;

--- a/src/Platform.X11/GameHostX11.hpp
+++ b/src/Platform.X11/GameHostX11.hpp
@@ -52,6 +52,8 @@ public:
 
     std::shared_ptr<Mouse> GetMouse() override;
 
+    std::shared_ptr<Gamepad> GetGamepad() override;
+
     SurfaceFormat GetBackBufferSurfaceFormat() const override;
 
     DepthFormat GetBackBufferDepthStencilFormat() const override;


### PR DESCRIPTION
This pull request adds gamepad support for Linux and Mac, using Input Subsystem and IOKit. It includes the gamepad API change. Following is the usage of this new gamepad API:

```cpp
auto gamepad = gameHost->GetGamepad();

// Print the name of the gamepad 1
auto caps1 = gamepad->GetState(PlayerIndex::One);
printf("Device Name = %s\n", caps1.Name.c_str());

// Print the name of the gamepad 2
auto caps2 = gamepad->GetState(PlayerIndex::Two);
printf("Device Name = %s\n", caps2.Name.c_str());

// Get the current state of a gamepad
auto state = gamepad->GetState(PlayerIndex::One);

if (state.IsConnected) {
    printf("Gamepad 1 is connected.\n");
}

if (state.Buttons.A == ButtonState::Pressed) {
    printf("Button A is pressed.\n");
}

if (state.DPad.Up == ButtonState::Pressed) {
    printf("DPad Up is pressed.\n");
}

if (state.ThumbSticks.Left.X > 0.0f) {
    printf("Left ThumStick: %f.\n", state.ThumbSticks.Left.X);
}
```
