### PR TITLE
 Fix scaling frame duration twice in Timer (#24)

### DIFF
--- a/experimental/Pomdog.Experimental/Gameplay2D/Simple2DGameEngine.cpp
+++ b/experimental/Pomdog.Experimental/Gameplay2D/Simple2DGameEngine.cpp
@@ -11,7 +11,6 @@ namespace Pomdog {
 
 Simple2DGameEngine::Simple2DGameEngine(const std::shared_ptr<GameHost>& gameHostIn)
     : gameHost(gameHostIn)
-    , gameTimer(gameHostIn->GetClock())
     , postProcessCompositor(gameHost->GetGraphicsDevice())
     , needToUpdateViewProjectionMatrix(true)
 {
@@ -86,9 +85,12 @@ void Simple2DGameEngine::OnViewportSizeChanged(int width, int height)
 
 void Simple2DGameEngine::Update()
 {
+    auto clock = gameHost->GetClock();
+    auto frameDuration = clock->GetFrameDuration();
+
     for (auto & entity : entityManager.QueryComponents<ActorComponent>()) {
         auto actor = entity.GetComponent<ActorComponent>();
-        actor->Act(entity, gameTimer.GetFrameDuration());
+        actor->Act(entity, frameDuration);
     }
 
     entityManager.Refresh();

--- a/experimental/Pomdog.Experimental/Gameplay2D/Simple2DGameEngine.hpp
+++ b/experimental/Pomdog.Experimental/Gameplay2D/Simple2DGameEngine.hpp
@@ -32,7 +32,6 @@ private:
 private:
     std::shared_ptr<GameHost> gameHost;
     ConnectionList connections;
-    Timer gameTimer;
 
     PostProcessCompositor postProcessCompositor;
     std::shared_ptr<GraphicsCommandList> commandListPreRender;

--- a/include/Pomdog/Application/Timer.hpp
+++ b/include/Pomdog/Application/Timer.hpp
@@ -35,8 +35,6 @@ public:
 
     Duration GetTotalTime() const;
 
-    Duration GetFrameDuration() const;
-
     bool IsSingleShot() const;
 
     void SetSingleShot(bool isSingleShot);
@@ -57,7 +55,6 @@ private:
     ScopedConnection connection;
     Optional<Duration> interval;
     Duration totalTime;
-    Duration frameDuration;
     double scale;
     bool enabled;
     bool isSingleShot;

--- a/src/Application/Timer.cpp
+++ b/src/Application/Timer.cpp
@@ -9,7 +9,6 @@ namespace Pomdog {
 
 Timer::Timer(GameClock & clock)
     : totalTime(Duration::zero())
-    , frameDuration(Duration::zero())
     , scale(1)
     , enabled(true)
     , isSingleShot(false)
@@ -18,7 +17,6 @@ Timer::Timer(GameClock & clock)
         if (!enabled) {
             return;
         }
-        this->frameDuration = (frameDurationIn * this->scale);
         totalTime += (frameDurationIn * scale);
 
         if (interval && (totalTime >= *interval)) {
@@ -68,11 +66,6 @@ bool Timer::IsEnabled() const
 Duration Timer::GetTotalTime() const
 {
     return this->totalTime;
-}
-
-Duration Timer::GetFrameDuration() const
-{
-    return this->frameDuration;
 }
 
 bool Timer::IsSingleShot() const

--- a/src/Application/Timer.cpp
+++ b/src/Application/Timer.cpp
@@ -19,7 +19,7 @@ Timer::Timer(GameClock & clock)
             return;
         }
         this->frameDuration = (frameDurationIn * this->scale);
-        this->totalTime += (frameDuration * this->scale);
+        totalTime += (frameDurationIn * scale);
 
         if (interval && (totalTime >= *interval)) {
             totalTime = *interval;

--- a/test/FrameworkTest/Application/TimerTest.cpp
+++ b/test/FrameworkTest/Application/TimerTest.cpp
@@ -16,7 +16,6 @@ TEST(Timer, TrivialCase)
     EXPECT_TRUE(timer.IsEnabled());
     EXPECT_FALSE(timer.IsSingleShot());
     EXPECT_FALSE(timer.GetInterval());
-    EXPECT_EQ(Duration::zero(), timer.GetFrameDuration());
     EXPECT_EQ(Duration::zero(), timer.GetTotalTime());
     EXPECT_EQ(1.0, timer.GetScale());
 }

--- a/test/FrameworkTest/Application/TimerTest.cpp
+++ b/test/FrameworkTest/Application/TimerTest.cpp
@@ -4,6 +4,7 @@
 #include <Pomdog/Application/GameClock.hpp>
 #include <gtest/iutest_switch.hpp>
 #include <chrono>
+#include <thread>
 
 using namespace Pomdog;
 
@@ -46,4 +47,23 @@ TEST(Timer, Scale)
 
     timer.SetScale(-0.5);
     EXPECT_EQ(-0.5, timer.GetScale());
+}
+
+TEST(Timer, Scaling)
+{
+    constexpr double scale = 0.4;
+    constexpr double epsilon = 0.001;
+
+    GameClock clock;
+    Timer timer(clock);
+    timer.SetScale(scale);
+    timer.Start();
+
+    for (int i = 0; i < 100; i++) {
+        clock.Tick();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    ASSERT_EQ(scale, timer.GetScale());
+    EXPECT_NEAR(clock.GetTotalGameTime().count() * scale, timer.GetTotalTime().count(), epsilon);
 }


### PR DESCRIPTION
This pull request fixes [#24](https://github.com/mogemimi/pomdog/issues/24). It also removes `Timer::GetFrameDuration()` which causes confusing with time scaling, so please use `GameClock::GetFrameDuration()` directly instead.