### PR TITLE
 Use std::string_view instead of std::string when possible

### DIFF
--- a/include/Pomdog/Utility/StringHelper.hpp
+++ b/include/Pomdog/Utility/StringHelper.hpp
@@ -5,36 +5,37 @@
 #include "Pomdog/Basic/Export.hpp"
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Pomdog {
 namespace StringHelper {
 
 POMDOG_EXPORT
-bool HasPrefix(const std::string& s, const std::string& prefix);
+bool HasPrefix(const std::string_view& s, const std::string_view& prefix);
 
 POMDOG_EXPORT
-bool HasSuffix(const std::string& s, const std::string& suffix);
+bool HasSuffix(const std::string_view& s, const std::string_view& suffix);
 
 POMDOG_EXPORT
-std::string TrimRight(const std::string& source, char separator);
+std::string_view TrimRight(const std::string_view& source, char separator);
 
 POMDOG_EXPORT
-std::string TrimLeft(const std::string& source, char separator);
+std::string_view TrimLeft(const std::string_view& source, char separator);
 
 POMDOG_EXPORT
-std::string TrimRight(const std::string& source, std::function<bool(char)> isSeparator);
+std::string_view TrimRight(const std::string_view& source, std::function<bool(char)> isSeparator);
 
 POMDOG_EXPORT
-std::string TrimLeft(const std::string& source, std::function<bool(char)> isSeparator);
+std::string_view TrimLeft(const std::string_view& source, std::function<bool(char)> isSeparator);
 
 POMDOG_EXPORT
-std::vector<std::string>
-Split(const std::string& source, char separator);
+std::vector<std::string_view>
+Split(const std::string_view& source, char separator);
 
 POMDOG_EXPORT
-std::vector<std::string>
-Split(const std::string& source, const std::string& separator);
+std::vector<std::string_view>
+Split(const std::string_view& source, const std::string_view& separator);
 
 POMDOG_EXPORT
 std::string Format(const char* format, ...)

--- a/src/Content/AssetBuilders/ShaderBuilder.cpp
+++ b/src/Content/AssetBuilders/ShaderBuilder.cpp
@@ -55,7 +55,8 @@ std::optional<std::string> IncludeGLSLFilesRecursive(
 
     auto lines = StringHelper::Split(text, '\n');
     text.clear();
-    for (const auto& line : lines) {
+    for (const auto& lineView : lines) {
+        std::string line{lineView};
         std::regex includeRegex(R"(\s*#\s*include\s+\"([\w\.\/\\]+)\")");
         std::smatch match;
 

--- a/src/InputSystem/GamepadMappings.cpp
+++ b/src/InputSystem/GamepadMappings.cpp
@@ -9,6 +9,7 @@
 #include "Pomdog/Utility/StringHelper.hpp"
 #include <algorithm>
 #include <array>
+#include <charconv>
 #include <unordered_map>
 #include <utility>
 
@@ -99,7 +100,11 @@ void ParseMapping(const char* source, GamepadMappings& mappings, std::string& na
         }
 
         if (index[0] == 'b') {
-            int i = std::atoi(StringHelper::TrimLeft(index, 'b').c_str());
+            auto s = StringHelper::TrimLeft(index, 'b');
+            int i = 0;
+            if (auto[p, err] = std::from_chars(s.data(), s.data() + s.size(), i); err != std::errc{}) {
+                i = -1;
+            }
             if ((i >= 0) && (i < static_cast<int>(mappings.buttons.size()))) {
                 mappings.buttons[i] = std::get<ButtonKind>(kind->second);
             }
@@ -107,7 +112,10 @@ void ParseMapping(const char* source, GamepadMappings& mappings, std::string& na
         else if (index[0] == 'a') {
             auto s = StringHelper::TrimRight(index, '~');
             s = StringHelper::TrimLeft(s, 'a');
-            int i = std::atoi(s.c_str());
+            int i = 0;
+            if (auto[p, err] = std::from_chars(s.data(), s.data() + s.size(), i); err != std::errc{}) {
+                i = -1;
+            }
             if ((i >= 0) && (i < static_cast<int>(mappings.axes.size()))) {
                 mappings.axes[i].thumbStick = std::get<ThumbStickKind>(kind->second);
                 mappings.axes[i].positiveTrigger = std::get<ButtonKind>(kind->second);
@@ -117,7 +125,10 @@ void ParseMapping(const char* source, GamepadMappings& mappings, std::string& na
             auto s = StringHelper::TrimRight(index, '~');
             s = StringHelper::TrimLeft(s, '+');
             s = StringHelper::TrimLeft(s, 'a');
-            int i = std::atoi(s.c_str());
+            int i = 0;
+            if (auto[p, err] = std::from_chars(s.data(), s.data() + s.size(), i); err != std::errc{}) {
+                i = -1;
+            }
             if ((i >= 0) && (i < static_cast<int>(mappings.axes.size()))) {
                 mappings.axes[i].positiveTrigger = std::get<ButtonKind>(kind->second);
             }
@@ -126,7 +137,10 @@ void ParseMapping(const char* source, GamepadMappings& mappings, std::string& na
             auto s = StringHelper::TrimRight(index, '~');
             s = StringHelper::TrimLeft(s, '-');
             s = StringHelper::TrimLeft(s, 'a');
-            int i = std::atoi(s.c_str());
+            int i = 0;
+            if (auto[p, err] = std::from_chars(s.data(), s.data() + s.size(), i); err != std::errc{}) {
+                i = -1;
+            }
             if ((i >= 0) && (i < static_cast<int>(mappings.axes.size()))) {
                 mappings.axes[i].negativeTrigger = std::get<ButtonKind>(kind->second);
             }

--- a/src/Utility/StringHelper.cpp
+++ b/src/Utility/StringHelper.cpp
@@ -7,7 +7,7 @@
 
 namespace Pomdog {
 
-bool StringHelper::HasPrefix(const std::string& s, const std::string& prefix)
+bool StringHelper::HasPrefix(const std::string_view& s, const std::string_view& prefix)
 {
     if (s.size() < prefix.size()) {
         return false;
@@ -15,7 +15,7 @@ bool StringHelper::HasPrefix(const std::string& s, const std::string& prefix)
     return (s.compare(0, prefix.size(), prefix) == 0);
 }
 
-bool StringHelper::HasSuffix(const std::string& s, const std::string& suffix)
+bool StringHelper::HasSuffix(const std::string_view& s, const std::string_view& suffix)
 {
     if (suffix.empty()) {
         return true;
@@ -26,41 +26,65 @@ bool StringHelper::HasSuffix(const std::string& s, const std::string& suffix)
     return (s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0);
 }
 
-std::string StringHelper::TrimRight(const std::string& source, char separator)
+std::string_view
+StringHelper::TrimRight(const std::string_view& source, char separator)
 {
-    const auto func = [&](char c) { return c != separator; };
-    std::string result(
-        std::begin(source), std::find_if(std::rbegin(source), std::rend(source), func).base());
-    return result;
+    auto v = source;
+    auto pos = v.find_last_not_of(separator);
+    if (pos != v.npos) {
+        POMDOG_ASSERT(v.size() >= (pos + 1));
+        v.remove_suffix(v.size() - (pos + 1));
+    }
+    else {
+        v.remove_suffix(v.size());
+    }
+    return v;
 }
 
-std::string StringHelper::TrimLeft(const std::string& source, char separator)
+std::string_view
+StringHelper::TrimLeft(const std::string_view& source, char separator)
 {
-    const auto func = [&](char c) { return c != separator; };
-    std::string result(std::find_if(std::begin(source), std::end(source), func), std::end(source));
-    return result;
+    auto v = source;
+    v.remove_prefix(std::min(v.find_first_not_of(separator), v.size()));
+    return v;
 }
 
-std::string
-StringHelper::TrimRight(const std::string& source, std::function<bool(char)> isSeparator)
+std::string_view
+StringHelper::TrimRight(const std::string_view& source, std::function<bool(char)> isSeparator)
 {
     auto func = std::not_fn(std::move(isSeparator));
-    std::string result(
-        std::begin(source), std::find_if(std::rbegin(source), std::rend(source), func).base());
-    return result;
+    auto v = source;
+    auto iter = std::find_if(std::rbegin(v), std::rend(v), func);
+    if (iter != std::rend(v)) {
+        auto pos = std::distance(std::rbegin(v), iter);
+        v.remove_suffix(pos);
+    }
+    else {
+        v.remove_suffix(v.size());
+    }
+    return v;
 }
 
-std::string StringHelper::TrimLeft(const std::string& source, std::function<bool(char)> isSeparator)
+std::string_view
+StringHelper::TrimLeft(const std::string_view& source, std::function<bool(char)> isSeparator)
 {
     auto func = std::not_fn(std::move(isSeparator));
-    std::string result(std::find_if(std::begin(source), std::end(source), func), std::end(source));
-    return result;
+    auto v = source;
+    auto iter = std::find_if(std::begin(source), std::end(source), func);
+    if (iter != std::end(v)) {
+        auto pos = std::distance(std::begin(v), iter);
+        v.remove_prefix(pos);
+    }
+    else {
+        v.remove_prefix(v.size());
+    }
+    return v;
 }
 
-std::vector<std::string>
-StringHelper::Split(const std::string& source, char separator)
+std::vector<std::string_view>
+StringHelper::Split(const std::string_view& source, char separator)
 {
-    std::vector<std::string> tokens;
+    std::vector<std::string_view> tokens;
     std::string::size_type start = 0;
     std::string::size_type end = 0;
     while ((end = source.find(separator, start)) != std::string::npos) {
@@ -71,10 +95,10 @@ StringHelper::Split(const std::string& source, char separator)
     return tokens;
 }
 
-std::vector<std::string>
-StringHelper::Split(const std::string& source, const std::string& separator)
+std::vector<std::string_view>
+StringHelper::Split(const std::string_view& source, const std::string_view& separator)
 {
-    std::vector<std::string> tokens;
+    std::vector<std::string_view> tokens;
     std::string::size_type start = 0;
     std::string::size_type end = 0;
     while ((end = source.find(separator, start)) != std::string::npos) {

--- a/test/Utility/StringHelperTest.cpp
+++ b/test/Utility/StringHelperTest.cpp
@@ -58,19 +58,27 @@ TEST_CASE("StringHelper", "[StringHelper]")
     SECTION("TrimLeft")
     {
         REQUIRE(StringHelper::TrimLeft("", 'a') == "");
+        REQUIRE(StringHelper::TrimLeft("a", 'a') == "");
+        REQUIRE(StringHelper::TrimLeft("aa", 'a') == "");
+        REQUIRE(StringHelper::TrimLeft("aaa", 'a') == "");
         REQUIRE(StringHelper::TrimLeft("BC", 'a') == "BC");
         REQUIRE(StringHelper::TrimLeft("aBC", 'a') == "BC");
         REQUIRE(StringHelper::TrimLeft("aaaaaBC", 'a') == "BC");
         REQUIRE(StringHelper::TrimLeft("aaBaaCaa", 'a') == "BaaCaa");
+        REQUIRE(StringHelper::TrimLeft("aaaaBaaaCaa", 'a') == "BaaaCaa");
     }
     SECTION("TrimLeft with func")
     {
         auto func = [](char c)-> bool { return c == 'a'; };
         REQUIRE(StringHelper::TrimLeft("", func) == "");
+        REQUIRE(StringHelper::TrimLeft("a", func) == "");
+        REQUIRE(StringHelper::TrimLeft("aa", func) == "");
+        REQUIRE(StringHelper::TrimLeft("aaa", func) == "");
         REQUIRE(StringHelper::TrimLeft("BC", func) == "BC");
         REQUIRE(StringHelper::TrimLeft("aBC", func) == "BC");
         REQUIRE(StringHelper::TrimLeft("aaaaaBC", func) == "BC");
         REQUIRE(StringHelper::TrimLeft("aaBaaCaa", func) == "BaaCaa");
+        REQUIRE(StringHelper::TrimLeft("aaaaBaaaCaa", func) == "BaaaCaa");
 
         auto isSpace = [](char c)-> bool { return ::isspace(c); };
         REQUIRE(StringHelper::TrimLeft("  ABC", isSpace) == "ABC");
@@ -79,17 +87,25 @@ TEST_CASE("StringHelper", "[StringHelper]")
     SECTION("TrimRight")
     {
         REQUIRE(StringHelper::TrimRight("", 'a') == "");
+        REQUIRE(StringHelper::TrimRight("a", 'a') == "");
+        REQUIRE(StringHelper::TrimRight("aa", 'a') == "");
+        REQUIRE(StringHelper::TrimRight("aaa", 'a') == "");
         REQUIRE(StringHelper::TrimRight("BCa", 'a') == "BC");
         REQUIRE(StringHelper::TrimRight("BCaaaaa", 'a') == "BC");
         REQUIRE(StringHelper::TrimRight("aaBaaCaa", 'a') == "aaBaaC");
+        REQUIRE(StringHelper::TrimRight("aaaaBaaaCaa", 'a') == "aaaaBaaaC");
     }
     SECTION("TrimRight with func")
     {
         auto func = [](char c)-> bool { return c == 'a'; };
         REQUIRE(StringHelper::TrimRight("", func) == "");
+        REQUIRE(StringHelper::TrimRight("a", func) == "");
+        REQUIRE(StringHelper::TrimRight("aa", func) == "");
+        REQUIRE(StringHelper::TrimRight("aaa", func) == "");
         REQUIRE(StringHelper::TrimRight("BCa", func) == "BC");
         REQUIRE(StringHelper::TrimRight("BCaaaaa", func) == "BC");
         REQUIRE(StringHelper::TrimRight("aaBaaCaa", func) == "aaBaaC");
+        REQUIRE(StringHelper::TrimRight("aaaaBaaaCaa", func) == "aaaaBaaaC");
 
         auto isSpace = [](char c)-> bool { return ::isspace(c); };
         REQUIRE(StringHelper::TrimRight("ABC  ", isSpace) == "ABC");


### PR DESCRIPTION
This pull request changes the`std::string` with the `std::string_view` for non-destructive string functions.