### PR TITLE
Fix potential null pointer access bug when window is created on Win32

### DIFF
--- a/src/Platform.Win32/GameWindowWin32.cpp
+++ b/src/Platform.Win32/GameWindowWin32.cpp
@@ -389,9 +389,11 @@ LRESULT CALLBACK GameWindowWin32::Impl::WindowProcedure(
             return TRUE;
         }
 
-        std::string text;
-        text += static_cast<char>(wParam);
-        window->eventQueue->Enqueue<InputTextEvent>(text);
+        if (window) {
+            std::string text;
+            text += static_cast<char>(wParam);
+            window->eventQueue->Enqueue<InputTextEvent>(text);
+        }
         return 0;
     }
     case WM_ENTERSIZEMOVE: {
@@ -438,10 +440,12 @@ LRESULT CALLBACK GameWindowWin32::Impl::WindowProcedure(
         return 0;
     }
     case WM_SETCURSOR: {
-        auto hitTest = lParam & 0xffff;
-        if (hitTest == HTCLIENT && window->gameCursor) {
-            SetCursor(*window->gameCursor);
-            return FALSE;
+        if (window) {
+            const auto hitTest = lParam & 0xffff;
+            if (hitTest == HTCLIENT && window->gameCursor) {
+                SetCursor(*window->gameCursor);
+                return FALSE;
+            }
         }
         break;
     }


### PR DESCRIPTION
This pull request added missing null pointer check `if (window) {}` and fixed the bug: https://github.com/mogemimi/pomdog/issues/39