### PR TITLE
Add missing link libraries for MetalKit

### DIFF
--- a/build/PomdogTest.xcodeproj/project.pbxproj
+++ b/build/PomdogTest.xcodeproj/project.pbxproj
@@ -113,6 +113,12 @@
 		D7703E0822FCB23400442403 /* ErrorsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703E0622FCB23400442403 /* ErrorsTest.cpp */; };
 		D7703E0A22FCB24700442403 /* DelegateTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703E0922FCB24700442403 /* DelegateTest.cpp */; };
 		D7703E0B22FCB24700442403 /* DelegateTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703E0922FCB24700442403 /* DelegateTest.cpp */; };
+		D7AD4A5D23F7D6B300E4A556 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A5A23F7D6B300E4A556 /* MetalKit.framework */; };
+		D7AD4A5F23F7D6BA00E4A556 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A5E23F7D6BA00E4A556 /* Metal.framework */; };
+		D7AD4A6123F7D6C100E4A556 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A6023F7D6C100E4A556 /* IOKit.framework */; };
+		D7AD4A6223F7D6D400E4A556 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A6023F7D6C100E4A556 /* IOKit.framework */; };
+		D7AD4A6323F7D6DB00E4A556 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A5E23F7D6BA00E4A556 /* Metal.framework */; };
+		D7AD4A6423F7D6E100E4A556 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A5A23F7D6B300E4A556 /* MetalKit.framework */; };
 		D9A0B1F8D2EEDA3FAEB1189C /* BoundingSphereTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B0A27C53B61D53FB2C8FCF9 /* BoundingSphereTest.cpp */; };
 		DE960EA2AD22C5A8FA2877FC /* QuaternionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BCA9759FC4E3E6735E7531D /* QuaternionTest.cpp */; };
 		DE967E47909AFDBEEFB99607 /* GameClockTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD17C83A321AA8BC76DFA4E /* GameClockTest.cpp */; };
@@ -220,6 +226,9 @@
 		D7703E0122FCB22900442403 /* SpinLockTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinLockTest.cpp; sourceTree = "<group>"; };
 		D7703E0622FCB23400442403 /* ErrorsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ErrorsTest.cpp; sourceTree = "<group>"; };
 		D7703E0922FCB24700442403 /* DelegateTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DelegateTest.cpp; sourceTree = "<group>"; };
+		D7AD4A5A23F7D6B300E4A556 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		D7AD4A5E23F7D6BA00E4A556 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		D7AD4A6023F7D6C100E4A556 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		D8F1F6F7CC0ACB1CF8F7DD09 /* KeyboardStateTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = KeyboardStateTest.cpp; sourceTree = "<group>"; };
 		DF87E2EA6D1C796C51A886A7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		DFD17C83A321AA8BC76DFA4E /* GameClockTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GameClockTest.cpp; sourceTree = "<group>"; };
@@ -241,6 +250,9 @@
 				A9D641961C343074006E14E0 /* libpomdog.a in Frameworks */,
 				3F233726FFBFFEBE36E2983D /* AudioToolBox.framework in Frameworks */,
 				5F7DB68F373F844793FC4D9D /* Cocoa.framework in Frameworks */,
+				D7AD4A6123F7D6C100E4A556 /* IOKit.framework in Frameworks */,
+				D7AD4A5F23F7D6BA00E4A556 /* Metal.framework in Frameworks */,
+				D7AD4A5D23F7D6B300E4A556 /* MetalKit.framework in Frameworks */,
 				7E14449EE47BF435E52F1C65 /* OpenAL.framework in Frameworks */,
 				CE0FB9D9F7E58DC14950C6D3 /* OpenGL.framework in Frameworks */,
 				C70AF5750080F8927CA84E9F /* QuartzCore.framework in Frameworks */,
@@ -251,11 +263,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9D641971C343079006E14E0 /* Pomdog.framework in Frameworks */,
 				A90B09AA1C25A774006E749D /* AudioToolBox.framework in Frameworks */,
 				A90B09AC1C25A774006E749D /* Cocoa.framework in Frameworks */,
+				D7AD4A6223F7D6D400E4A556 /* IOKit.framework in Frameworks */,
+				D7AD4A6323F7D6DB00E4A556 /* Metal.framework in Frameworks */,
+				D7AD4A6423F7D6E100E4A556 /* MetalKit.framework in Frameworks */,
 				A90B09AB1C25A774006E749D /* OpenAL.framework in Frameworks */,
 				A90B09AD1C25A774006E749D /* OpenGL.framework in Frameworks */,
+				A9D641971C343079006E14E0 /* Pomdog.framework in Frameworks */,
 				A90B09AE1C25A774006E749D /* QuartzCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,6 +343,9 @@
 			children = (
 				FF2591B788324D90FD154981 /* AudioToolBox.framework */,
 				DF87E2EA6D1C796C51A886A7 /* Cocoa.framework */,
+				D7AD4A6023F7D6C100E4A556 /* IOKit.framework */,
+				D7AD4A5E23F7D6BA00E4A556 /* Metal.framework */,
+				D7AD4A5A23F7D6B300E4A556 /* MetalKit.framework */,
 				1C8B6E715F53F2A76D934FF5 /* OpenAL.framework */,
 				8740D20FB4E0A88300F8C2A5 /* OpenGL.framework */,
 				8821B1A3B9B0B5552E6FBFB6 /* QuartzCore.framework */,

--- a/build/pomdog.xcodeproj/project.pbxproj
+++ b/build/pomdog.xcodeproj/project.pbxproj
@@ -427,6 +427,8 @@
 		D7703DF822FCB1BB00442403 /* SpinLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703DF622FCB1BB00442403 /* SpinLock.cpp */; };
 		D7703E0D22FCB26800442403 /* Errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703E0C22FCB26800442403 /* Errors.cpp */; };
 		D7703E0E22FCB26800442403 /* Errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7703E0C22FCB26800442403 /* Errors.cpp */; };
+		D7AD4A3A23F7D45400E4A556 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A3923F7D45400E4A556 /* MetalKit.framework */; };
+		D7AD4A3B23F7D47D00E4A556 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A3923F7D45400E4A556 /* MetalKit.framework */; };
 		D7C188D72395DFBB00C3E381 /* EntityManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7C188D42395DFBB00C3E381 /* EntityManager.cpp */; };
 		D7C188D82395DFBB00C3E381 /* EntityManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7C188D42395DFBB00C3E381 /* EntityManager.cpp */; };
 		D7C188D92395DFBB00C3E381 /* ComponentTypeIndex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D7C188D52395DFBB00C3E381 /* ComponentTypeIndex.cpp */; };
@@ -1147,6 +1149,7 @@
 		D7703E0C22FCB26800442403 /* Errors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Errors.cpp; sourceTree = "<group>"; };
 		D7703E0F22FCB28800442403 /* Errors.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Errors.hpp; sourceTree = "<group>"; };
 		D79110B22382E1AA00C268C3 /* VertexBufferBindingGL4.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VertexBufferBindingGL4.hpp; sourceTree = "<group>"; };
+		D7AD4A3923F7D45400E4A556 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		D7C188D42395DFBB00C3E381 /* EntityManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntityManager.cpp; sourceTree = "<group>"; };
 		D7C188D52395DFBB00C3E381 /* ComponentTypeIndex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ComponentTypeIndex.cpp; sourceTree = "<group>"; };
 		D7C188D62395DFBB00C3E381 /* Entity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Entity.cpp; sourceTree = "<group>"; };
@@ -1251,6 +1254,7 @@
 				A9D641941C34302C006E14E0 /* Cocoa.framework in Frameworks */,
 				A9E4B875210CDE03003F87DC /* IOKit.framework in Frameworks */,
 				A997F6DC1CAEFB0800926392 /* Metal.framework in Frameworks */,
+				D7AD4A3B23F7D47D00E4A556 /* MetalKit.framework in Frameworks */,
 				A9D641921C34301C006E14E0 /* OpenAL.framework in Frameworks */,
 				A9D641931C343023006E14E0 /* OpenGL.framework in Frameworks */,
 				A9D641951C343034006E14E0 /* QuartzCore.framework in Frameworks */,
@@ -1270,6 +1274,7 @@
 				667D66568DF02EFA74F073DE /* Cocoa.framework in Frameworks */,
 				A9E4B876210CDE12003F87DC /* IOKit.framework in Frameworks */,
 				A997F6DD1CAEFB1800926392 /* Metal.framework in Frameworks */,
+				D7AD4A3A23F7D45400E4A556 /* MetalKit.framework in Frameworks */,
 				BECB75C4B0471C4F7255D067 /* OpenAL.framework in Frameworks */,
 				3731B1EE2512BA451CA8E5D7 /* OpenGL.framework in Frameworks */,
 				727F4C3A231FF04CBE2A4B90 /* QuartzCore.framework in Frameworks */,
@@ -2685,10 +2690,11 @@
 		E5BCF0B13AAAF8E1F45AEBD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A9E4B874210CDE03003F87DC /* IOKit.framework */,
 				A997F6DE1CAEFB3E00926392 /* AudioToolbox.framework */,
 				F247CD851F16A8BCEC2E5BA1 /* Cocoa.framework */,
+				A9E4B874210CDE03003F87DC /* IOKit.framework */,
 				A997F6DB1CAEFB0800926392 /* Metal.framework */,
+				D7AD4A3923F7D45400E4A556 /* MetalKit.framework */,
 				E67C9ABE05AB8179C6615644 /* OpenAL.framework */,
 				EB039FAE65C607A60DDBB49C /* OpenGL.framework */,
 				A0AE4521498F69CE846F2EFB /* QuartzCore.framework */,

--- a/build/pomdog/CMakeLists.txt
+++ b/build/pomdog/CMakeLists.txt
@@ -1093,6 +1093,7 @@ endif()
 
 if(POMDOG_USE_METAL AND (POMDOG_TARGET_PLATFORM MATCHES "Mac"))
   target_link_libraries(pomdog_static INTERFACE "-framework Metal")
+  target_link_libraries(pomdog_static INTERFACE "-framework MetalKit")
 endif()
 
 if(POMDOG_USE_OPENAL AND (POMDOG_TARGET_PLATFORM MATCHES "Mac"))

--- a/examples/FeatureShowcase/CMakeLists.txt
+++ b/examples/FeatureShowcase/CMakeLists.txt
@@ -202,6 +202,7 @@ if(APPLE)
     "-framework Cocoa"
     "-framework IOKit"
     "-framework Metal"
+    "-framework MetalKit"
     "-framework OpenAL"
     "-framework OpenGL"
     "-framework QuartzCore"

--- a/examples/Pong/CMakeLists.txt
+++ b/examples/Pong/CMakeLists.txt
@@ -121,6 +121,7 @@ if(APPLE)
     "-framework Cocoa"
     "-framework IOKit"
     "-framework Metal"
+    "-framework MetalKit"
     "-framework OpenAL"
     "-framework OpenGL"
     "-framework QuartzCore"

--- a/examples/QuickStart/Builds/QuickStart.xcodeproj/project.pbxproj
+++ b/examples/QuickStart/Builds/QuickStart.xcodeproj/project.pbxproj
@@ -16,9 +16,12 @@
 		A98BE0BE1CC22736008696A8 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98BE0BD1CC22736008696A8 /* Cocoa.framework */; };
 		A98BE0C01CC2273C008696A8 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98BE0BF1CC2273C008696A8 /* Metal.framework */; };
 		A98BE0C21CC22744008696A8 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98BE0C11CC22744008696A8 /* MetalKit.framework */; };
-		A98BE0C41CC22754008696A8 /* ModelIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98BE0C31CC22754008696A8 /* ModelIO.framework */; };
 		A98BE0D11CC22850008696A8 /* Pomdog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A98BE0D01CC2282B008696A8 /* Pomdog.framework */; };
 		A9C8A5191E04092B0068F062 /* Pomdog.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = A98BE0D01CC2282B008696A8 /* Pomdog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D7AD4A4423F7D4E600E4A556 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A4223F7D4E600E4A556 /* OpenGL.framework */; };
+		D7AD4A4623F7D4FC00E4A556 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A4523F7D4FB00E4A556 /* OpenAL.framework */; };
+		D7AD4A4823F7D50E00E4A556 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A4723F7D50E00E4A556 /* IOKit.framework */; };
+		D7AD4A5123F7D66800E4A556 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7AD4A5023F7D66800E4A556 /* QuartzCore.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +77,10 @@
 		A98BE0C11CC22744008696A8 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		A98BE0C31CC22754008696A8 /* ModelIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ModelIO.framework; path = System/Library/Frameworks/ModelIO.framework; sourceTree = SDKROOT; };
 		A98BE0C61CC2282A008696A8 /* pomdog.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = pomdog.xcodeproj; path = ../../../build/pomdog.xcodeproj; sourceTree = "<group>"; };
+		D7AD4A4223F7D4E600E4A556 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		D7AD4A4523F7D4FB00E4A556 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
+		D7AD4A4723F7D50E00E4A556 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		D7AD4A5023F7D66800E4A556 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,10 +89,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A98BE0BE1CC22736008696A8 /* Cocoa.framework in Frameworks */,
+				D7AD4A4823F7D50E00E4A556 /* IOKit.framework in Frameworks */,
 				A98BE0C01CC2273C008696A8 /* Metal.framework in Frameworks */,
 				A98BE0C21CC22744008696A8 /* MetalKit.framework in Frameworks */,
-				A98BE0C41CC22754008696A8 /* ModelIO.framework in Frameworks */,
+				D7AD4A4623F7D4FC00E4A556 /* OpenAL.framework in Frameworks */,
+				D7AD4A4423F7D4E600E4A556 /* OpenGL.framework in Frameworks */,
 				A98BE0D11CC22850008696A8 /* Pomdog.framework in Frameworks */,
+				D7AD4A5123F7D66800E4A556 /* QuartzCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,6 +156,10 @@
 		A98BE0C51CC2275E008696A8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D7AD4A5023F7D66800E4A556 /* QuartzCore.framework */,
+				D7AD4A4723F7D50E00E4A556 /* IOKit.framework */,
+				D7AD4A4523F7D4FB00E4A556 /* OpenAL.framework */,
+				D7AD4A4223F7D4E600E4A556 /* OpenGL.framework */,
 				A98BE0BD1CC22736008696A8 /* Cocoa.framework */,
 				A98BE0BF1CC2273C008696A8 /* Metal.framework */,
 				A98BE0C11CC22744008696A8 /* MetalKit.framework */,

--- a/examples/QuickStart/CMakeLists.txt
+++ b/examples/QuickStart/CMakeLists.txt
@@ -121,6 +121,7 @@ if(APPLE)
     "-framework Cocoa"
     "-framework IOKit"
     "-framework Metal"
+    "-framework MetalKit"
     "-framework OpenAL"
     "-framework OpenGL"
     "-framework QuartzCore"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,6 +134,7 @@ if(APPLE)
     "-framework Cocoa"
     "-framework IOKit"
     "-framework Metal"
+    "-framework MetalKit"
     "-framework OpenAL"
     "-framework OpenGL"
     "-framework QuartzCore"


### PR DESCRIPTION
I added the missing link library `MetalKit.framework`, and fixed this issue https://github.com/mogemimi/pomdog/issues/41.