### PR TITLE
Set NSHighResolutionCapable to false by default

### DIFF
--- a/examples/FeatureShowcase/Platform.Cocoa/Info.plist
+++ b/examples/FeatureShowcase/Platform.Cocoa/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/examples/Pong/Platform.Cocoa/Info.plist
+++ b/examples/Pong/Platform.Cocoa/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/examples/QuickStart/Platform.Cocoa/Info.plist
+++ b/examples/QuickStart/Platform.Cocoa/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
I added a flag `NSHighResolutionCapable = false` to turn off high resolution support temporarily with this pull request, and this PR fixes #41 . This change is temporary workaround, and there are plans to provide high-resolution support in the future for retina display.